### PR TITLE
Refactor timeToString locale handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.2.4
+
+- Refactor timeToString react hook render issues by moving the locale hook out of the method (#13)
+
 ## 25.2.3
 
-- Enable TreeMenu data obtainment based on loader params change, add a custom classname for treemenu card, add new colors to the palette (!10)
+- Enable TreeMenu data obtainment based on loader params change, add a custom classname for treemenu card, add new colors to the palette (#10)
 
 ## 25.2.1
 
@@ -10,10 +14,10 @@
 
 ## 25.1.3
 
-- Replace yarn with pnpm in github workflow (!3)
+- Replace yarn with pnpm in github workflow (#3)
 
 ## 25.1.2
 
 ### Refactor
 
-- Allow publish to npm only on tag build (!1)
+- Allow publish to npm only on tag build (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.2.4
 
-- Refactor timeToString react hook render issues by moving the locale hook out of the method (pull request #13)
+- Refactor timeToString react hook render issues by moving the locale hook out of the method (#13)
 
 ## 25.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.2.4
 
-- Refactor timeToString react hook render issues by moving the locale hook out of the method (#13)
+- Refactor timeToString react hook render issues by moving the locale hook out of the method (pull request #13)
 
 ## 25.2.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.2.3",
+	"version": "25.2.4",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DateTime/index.js
+++ b/src/components/DateTime/index.js
@@ -18,7 +18,7 @@ export function DateTime(props) {
 		);
 	}
 
-	const date = timeToString(props.value, props.dateTimeFormat);
+	const date = timeToString(props.value, props.dateTimeFormat, locale);
 
 	// Check for invalid date from timeToString method
 	if (date === 'Invalid Date') {

--- a/src/components/DateTime/timeToString.js
+++ b/src/components/DateTime/timeToString.js
@@ -1,7 +1,6 @@
 import { format, parseISO, formatISO, parse, formatDistanceToNow } from 'date-fns';
-import useDateFNSLocale from './useDateFNSLocale';
 
-const timeToString = (value, dateTimeFormat = "medium") => {
+const timeToString = (value, dateTimeFormat = "medium", locale = undefined) => {
 
 	if (value == undefined) {
 		return 'Invalid Date';
@@ -26,21 +25,21 @@ const timeToString = (value, dateTimeFormat = "medium") => {
 		if (parseISO(value) == "Invalid Date") {
 			return 'Invalid Date';
 		} else {
-			date = formatDate(parseISO(value), dateTimeFormat);
+			date = formatDate(parseISO(value), dateTimeFormat, locale);
 		}
 	} else {
 		if (value > 9999999999) {
-			date = formatDate(value, dateTimeFormat);
+			date = formatDate(value, dateTimeFormat, locale);
 		} else {
-			date = formatDate(value * 1000, dateTimeFormat);
+			date = formatDate(value * 1000, dateTimeFormat, locale);
 		}
 	}
 
 	return {date: date.date, distanceToNow: date.distanceToNow};
 }
 
-const formatDate = (value, dateTimeFormat) => {
-	const locale = useDateFNSLocale();
+const formatDate = (value, dateTimeFormat, locale) => {
+
 	switch(dateTimeFormat) {
 		case "long": return {date: format(value, 'PPpp', { locale }), distanceToNow: formatDistanceToNow(value, { addSuffix: true, locale: locale })};
 		case "iso": return {date: formatISO(value), distanceToNow: formatDistanceToNow(value, { addSuffix: true, locale: locale })};


### PR DESCRIPTION
This MR resolve issue with react hook renders within timeToString method by:

- moving locale hook only to the datetime render method
- add locale prop to timeToString