### PR TITLE
Display bigint in the Renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.2.10
+
+- Display biging values in the Renderer. Convert bigint to string (#22)
+
 ## 25.2.9
 
 - Add splang format processing for DateTime (#17)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.2.9",
+	"version": "25.2.10",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/abc/Renderer.js
+++ b/src/abc/Renderer.js
@@ -25,7 +25,7 @@ export class Renderer extends Component {
 			)
 		}
 		// Render span with value inside as a default
-		return (<span>{value}</span>);
+		return (<span>{(typeof value === "bigint") ? value.toString() : value}</span>);
 	}
 
 	plain(key, value, schemaField)	{


### PR DESCRIPTION
This request is related to a change in GitLab. I got rid of the error display in Gitlab. This code will help to display bigint on the UI

- I added a check if the value is a bigint, if it is, I turn it into a string so that it will be displayed on the UI.
- conversion to a string does not change the accuracy of the value




before:
![image](https://github.com/user-attachments/assets/8e59e399-1d91-49bb-bbf0-00022c89f985)



after:
![image](https://github.com/user-attachments/assets/a9799fdf-59fe-4413-94f5-14009be3a0a4)
