### PR TITLE
Fix issue with bigint in IP address classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.2.12
+
+- Update babel.config to allow handling recent features like BigInt on compilation (#24)
+
 ## 25.2.11
 
 - Replace isValidIP and isPrivateIP utils by classifyIPAddress feature which classifies the IP addresses (#23)

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,16 @@
 module.exports = {
-	presets: ["@babel/preset-env", "@babel/preset-react"],
+	presets: [
+		[
+			"@babel/preset-env",
+			{
+				targets: {
+					esmodules: true, // Use node 14 or higher
+				},
+				shippedProposals: true, // Allows modern features like BigInt
+			}
+		],
+		"@babel/preset-react"
+	],
 	plugins: [
 		"@babel/plugin-transform-runtime",
 		[

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,9 +4,9 @@ module.exports = {
 			"@babel/preset-env",
 			{
 				targets: {
-					esmodules: true, // Use node 14 or higher
+					esmodules: true, // Targeting modern environments that support ESModules
 				},
-				shippedProposals: true, // Allows modern features like BigInt
+				shippedProposals: true, // Allows modern (proposed/not widely implemented) features like BigInt regardless the environment
 			}
 		],
 		"@babel/preset-react"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.2.11",
+	"version": "25.2.12",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -183,33 +183,36 @@ const ipv6Ranges = [
 	}
 ]
 
-
 function classifyIPv4(ipAddress) {
+	const ip = BigInt(ipAddress); // Ensure input is BigInt
+
 	for (const range of ipv4Ranges) {
-		const mask = BigInt(2) ** BigInt(32 - range.mask) - BigInt(1);
+		const mask = (1n << BigInt(32 - range.mask)) - 1n;
 		const network = range.block & ~mask;
-		const ipNetwork = ipAddress & ~mask;
-		
+		const ipNetwork = ip & ~mask;
+
 		if (network === ipNetwork) {
 			return range.class;
 		}
 	}
 
-	return "IPv4 public";  // If no range matches, it's a public IP
+	return "IPv4 public";
 }
 
 function classifyIPv6(ipAddress) {
+	const ip = BigInt(ipAddress); // Ensure input is BigInt
+
 	for (const range of ipv6Ranges) {
-		const mask = BigInt(2) ** BigInt(128 - range.mask) - BigInt(1);
+		const mask = (1n << BigInt(128 - range.mask)) - 1n;
 		const network = range.block & ~mask;
-		const ipNetwork = ipAddress & ~mask;
-		
+		const ipNetwork = ip & ~mask;
+
 		if (network === ipNetwork) {
 			return range.class;
 		}
 	}
 
-	return "IPv6 public";  // If no range matches, it's a public IP
+	return "IPv6 public";
 }
 
 

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -196,7 +196,7 @@ function classifyIPv4(ipAddress) {
 		}
 	}
 
-	return "IPv4 public";
+	return "IPv4 public"; // If no range matches, it's a public IP
 }
 
 function classifyIPv6(ipAddress) {
@@ -212,7 +212,7 @@ function classifyIPv6(ipAddress) {
 		}
 	}
 
-	return "IPv6 public";
+	return "IPv6 public"; // If no range matches, it's a public IP
 }
 
 

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -183,36 +183,33 @@ const ipv6Ranges = [
 	}
 ]
 
+
 function classifyIPv4(ipAddress) {
-	const ip = BigInt(ipAddress); // Ensure input is BigInt
-
 	for (const range of ipv4Ranges) {
-		const mask = (1n << BigInt(32 - range.mask)) - 1n;
+		const mask = BigInt(2) ** BigInt(32 - range.mask) - BigInt(1);
 		const network = range.block & ~mask;
-		const ipNetwork = ip & ~mask;
-
+		const ipNetwork = ipAddress & ~mask;
+		
 		if (network === ipNetwork) {
 			return range.class;
 		}
 	}
 
-	return "IPv4 public"; // If no range matches, it's a public IP
+	return "IPv4 public";  // If no range matches, it's a public IP
 }
 
 function classifyIPv6(ipAddress) {
-	const ip = BigInt(ipAddress); // Ensure input is BigInt
-
 	for (const range of ipv6Ranges) {
-		const mask = (1n << BigInt(128 - range.mask)) - 1n;
+		const mask = BigInt(2) ** BigInt(128 - range.mask) - BigInt(1);
 		const network = range.block & ~mask;
-		const ipNetwork = ip & ~mask;
-
+		const ipNetwork = ipAddress & ~mask;
+		
 		if (network === ipNetwork) {
 			return range.class;
 		}
 	}
 
-	return "IPv6 public"; // If no range matches, it's a public IP
+	return "IPv6 public";  // If no range matches, it's a public IP
 }
 
 


### PR DESCRIPTION
- update babel config to allow modern features like bigint when library is compiled