### PR TITLE
Update conditions for the `classyfyIPAddress` to check ip spalng objects with keys `h` and `l`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.2.19
 
-- Updated conditions for the `classyfyIPAddress` to check ip spalng objects with keys `h` and `l`. (#31)
+- Updated conditions for the `classyfyIPAddress` to check ip spalng objects with keys `h` and `l`. (#33)
 
 ## 25.2.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.2.19
+
+- Updated conditions for the `classyfyIPAddress` to check ip spalng objects with keys `h` and `l`. (#31)
+
 ## 25.2.18
 
 - Refactor IP address classification to comphrehend the value normalization and proper IP address classification. (#30)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.2.19",
+	"version": "25.2.20",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.2.18",
+	"version": "25.2.19",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -13,7 +13,7 @@ function parseIPv4(ipAddress) {
 	if (typeof ipAddress === 'bigint') {
 		bigintIP4Address = ipAddress;
 	}
-	else if (typeof ipAddress === 'object' && ipAddress.h && ipAddress.l) {
+	else if (typeof ipAddress === 'object' && 'h' in ipAddress && 'l' in ipAddress) {
 		// This part can be removed in Jan 2026 when object form of IP address is removed from the codebase
 		bigintIP4Address = (BigInt(ipAddress.h) << 64n) + BigInt(ipAddress.l);
 	}
@@ -63,7 +63,7 @@ function parseIPv6(ipAddress) {
 	else if (typeof ipAddress === 'bigint') {
 		return ipAddress;
 	}
-	else if (typeof ipAddress === 'object' && ipAddress.h && ipAddress.l) {
+	else if (typeof ipAddress === 'object' && 'h' in ipAddress && 'l' in ipAddress) {
 		// This part can be removed in Jan 2026 when object form of IP address is removed from the codebase
 		return (BigInt(ipAddress.h) << 64n) + BigInt(ipAddress.l);
 	}


### PR DESCRIPTION
The conditions for checking the presence of keys have been updated. Js recognises bigint in the condition as a falsy value. Therefore, the old checks did not work.