### PR TITLE
Increase defensiveness of rows in DataTable2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.6.2
+
+- Increase defensiveness in DataTable2 when rows are of unsupported type (#44)
+
 ## 25.6.1
 
 - Remove `isoCodeCountries` lookup util. This has been moved into lmio_webui_components (#40)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.6.1",
+	"version": "25.6.2",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -65,6 +65,13 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 			const ret = await loader({ params, loaderParams, setRows, setCount });
 			if (ret != undefined) {
 				const { count, rows } = ret;
+				// Validation on rows type. If not an array, it will fallback to the defaults.
+				if (!Array.isArray(rows)) {
+					setRows([]);
+					setCount(0);
+					app.addAlert('danger', t('General|Failed to load rows to the data table. Rows are of unsupported type {{type}}.', { type: typeof rows }));
+					return;
+				}
 				setRows(rows);
 				setCount(count);
 			}


### PR DESCRIPTION
- increase defensiveness on unsupported rows type of DataTable2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when loading table data to prevent unsupported data types from being displayed. An alert will notify users if loading fails due to invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->