### PR TITLE
Implement Flowbite illustrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.6.3
+
+- Add `FlowbiteIllustration.jsx` component to handle rendering of illustrations on informational screens (#41)
+
 ## 25.6.2
 
 - Increase defensiveness in DataTable2 when rows are of unsupported type (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.6.3
 
-- Add `FlowbiteIllustration.jsx` component to handle rendering of illustrations on informational screens (#41)
+- Add `FlowbiteIllustration.jsx` component to handle rendering of illustrations on informational screens (#45)
 
 ## 25.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 26.1.2
+
+- Add `FlowbiteIllustration` component - use for loading illustrations into informational screens (#45)
+
 ## 26.1.1
 
 - Upgrade to react v19, remove redux dependency and replace it with custom redux-like context and AppStore, replace obsoleted `react-json-view` library with `@microlink/react-json-view` (#35)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.1",
+	"version": "26.1.2",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.6.2",
+	"version": "25.6.3",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -13,11 +13,12 @@ export const FlowbiteIllustration = ({
     const illustrationSrc = `${basePath}/${name}.svg`;
 
     return (
-        <div className={className}>
+        <div className='text-center'>
             <img 
                 src={illustrationSrc}
                 alt={title || `${name} illustration`}
                 title={title}
+				className={className}
                 style={{ 
                     width, 
                     height,

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -1,11 +1,29 @@
 import React, { useState } from 'react';
 
+/**
+ * FlowbiteIllustration - Secure SVG illustration component
+ * 
+ * Features:
+ * - Path traversal protection (sanitizes basePath and name)
+ * - Graceful error handling (collapses to 0 height on load failure) and displays nothing
+ * - Maintains aspect ratio when height is specified
+ * 
+ * Props:
+ * @param {string} name - SVG filename (required, alphanumeric/hyphens/underscores only)
+ * @param {string} className - CSS classes for img element
+ * @param {string} title - Accessibility title
+ * @param {string} basePath - Base directory (default: '/media/illustrations')
+ * @param {string} height - Container height (e.g., "200px", auto-width maintains ratio)
+ * 
+ * Usage:
+ * <FlowbiteIllustration name="welcome" height="300px" />
+ */
 export const FlowbiteIllustration = ({
-	name,
-	className = '', 
-	title = '',
-	basePath = '/media/illustrations',
-	height,
+    name,
+    className = '', 
+    title = '',
+    basePath = '/media/illustrations',
+    height,
 }) => {
 	const [hasError, setHasError] = useState(false);
 
@@ -23,7 +41,7 @@ export const FlowbiteIllustration = ({
 	// Sanitize the name to prevent path traversal and ensure valid filename
 	const sanitizedName = name
 		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
-		?.toLowerCase(); // Normalize to lowercase
+		?.toLowerCase();
 
 	if (!sanitizedName) {
 		console.warn(`Invalid or empty illustration name: '${name}'`);
@@ -32,6 +50,8 @@ export const FlowbiteIllustration = ({
 
 	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
 
+	/* For invalid images, sets optional height to 0 to avoid layout shifts
+	For valid images, uses the provided height or fills available space */
 	const containerStyle = hasError ? { height : 0 } : ( height ? { height } : {});
 
 	return (

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export const FlowbiteIllustration = ({ 
+    name, 
+    className = '', 
+    width = '300px',
+    height = 'auto',
+    title = ''
+}) => {
+    // Base path to your illustrations
+    const basePath = '/media/illustrations';
+
+    const illustrationSrc = `${basePath}/${name}.svg`;
+
+    return (
+        <div className={className}>
+            <img 
+                src={illustrationSrc}
+                alt={title || `${name} illustration`}
+                title={title}
+                style={{ 
+                    width, 
+                    height,
+                    maxWidth: '100%',
+                }}
+                onError={(e) => {
+                    console.warn(`Illustration '${name}' failed to load from ${illustrationSrc}`);
+                    e.target.style.display = 'none';
+                }}
+            />
+        </div>
+    );
+};

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -8,15 +8,26 @@ export const FlowbiteIllustration = ({
 	title = '',
 	basePath = '/media/illustrations',
 }) => {
+	// Sanitize the basePath to prevent path traversal
+	const sanitizedBasePath = basePath
+		?.replace(/\.\./g, '') // Remove path traversal attempts
+		?.replace(/\/+/g, '/') // Replace multiple slashes with single slash
+		?.replace(/\/$/, ''); // Remove trailing slash
+
 	// Sanitize the name to prevent path traversal and ensure valid filename
 	const sanitizedName = name
 		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
 		?.toLowerCase(); // Normalize to lowercase
 
-if (!sanitizedName) {
-	console.warn(`Invalid or empty illustration name: '${name}'`);
-	return null;
-}	
+	if (!sanitizedBasePath) {
+		console.warn(`Invalid base path: '${basePath}'`);
+		return null;
+	}
+
+	if (!sanitizedName) {
+		console.warn(`Invalid or empty illustration name: '${name}'`);
+		return null;
+	}	
 
 	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
 

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -14,15 +14,15 @@ export const FlowbiteIllustration = ({
 		?.replace(/\/+/g, '/') // Replace multiple slashes with single slash
 		?.replace(/\/$/, ''); // Remove trailing slash
 
-	// Sanitize the name to prevent path traversal and ensure valid filename
-	const sanitizedName = name
-		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
-		?.toLowerCase(); // Normalize to lowercase
-
 	if (!sanitizedBasePath) {
 		console.warn(`Invalid base path: '${basePath}'`);
 		return null;
 	}
+
+	// Sanitize the name to prevent path traversal and ensure valid filename
+	const sanitizedName = name
+		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
+		?.toLowerCase(); // Normalize to lowercase
 
 	if (!sanitizedName) {
 		console.warn(`Invalid or empty illustration name: '${name}'`);

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -1,34 +1,42 @@
 import React from 'react';
 
-export const FlowbiteIllustration = ({ 
-    name, 
-    className = '', 
-    width = '300px',
-    height = 'auto',
-    title = ''
+export const FlowbiteIllustration = ({
+	name,
+	className = '', 
+	width = '300px',
+	height = 'auto',
+	title = '',
+	basePath = '/media/illustrations',
 }) => {
-    // Base path to your illustrations
-    const basePath = '/media/illustrations';
+	// Sanitize the name to prevent path traversal and ensure valid filename
+	const sanitizedName = name
+		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
+		?.toLowerCase(); // Normalize to lowercase
 
-    const illustrationSrc = `${basePath}/${name}.svg`;
+if (!sanitizedName) {
+	console.warn(`Invalid or empty illustration name: '${name}'`);
+	return null;
+}	
 
-    return (
-        <div className='text-center'>
-            <img 
-                src={illustrationSrc}
-                alt={title || `${name} illustration`}
-                title={title}
+	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
+
+	return (
+		<div className='text-center'>
+			<img 
+				src={illustrationSrc}
+				alt={title || `${name} illustration`}
+				title={title}
 				className={className}
-                style={{ 
-                    width, 
-                    height,
-                    maxWidth: '100%',
-                }}
-                onError={(e) => {
-                    console.warn(`Illustration '${name}' failed to load from ${illustrationSrc}`);
-                    e.target.style.display = 'none';
-                }}
-            />
-        </div>
-    );
+				style={{ 
+					width, 
+					height,
+					maxWidth: '100%',
+				}}
+				onError={(e) => {
+					console.warn(`Illustration '${name}' failed to load from ${illustrationSrc}`);
+					e.target.style.display = 'none';
+				}}
+			/>
+		</div>
+	);
 };

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -10,10 +10,10 @@ import React, { useState } from 'react';
  * 
  * Props:
  * @param {string} name - SVG filename (required, alphanumeric/hyphens/underscores only)
+ * currently, we have: [ access, error, invite, unauthorized ]
  * @param {string} className - CSS classes for img element
  * @param {string} title - Accessibility title
  * @param {string} basePath - Base directory (default: '/media/illustrations')
- * @param {string} height - Container height (e.g., "200px", auto-width maintains ratio)
  * 
  * Usage:
  * <FlowbiteIllustration name="welcome" height="300px" />
@@ -23,10 +23,7 @@ export const FlowbiteIllustration = ({
     className = '', 
     title = '',
     basePath = '/media/illustrations',
-    height,
 }) => {
-	const [hasError, setHasError] = useState(false);
-
 	// Sanitize the basePath to prevent path traversal
 	const sanitizedBasePath = basePath
 		?.replace(/\.\./g, '') // Remove path traversal attempts
@@ -50,24 +47,15 @@ export const FlowbiteIllustration = ({
 
 	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
 
-	/* For invalid images, sets optional height to 0 to avoid layout shifts
-	For valid images, uses the provided height or fills available space */
-	const containerStyle = hasError ? { height : 0 } : ( height ? { height } : {});
-
 	return (
 		<div className='text-center' style={containerStyle}>
 			<img 
 				src={illustrationSrc}
 				alt={title || `${name} illustration`}
 				title={title}
-				className={className}
-				style={{ 
-					width: '100%',
-					height: '100%',
-				}}
+				className={`h-100 w-100 ${className}`}
 				onError={(e) => {
 					console.warn(`Illustration '${name}' failed to load from ${illustrationSrc}`);
-					setHasError(true);
 					e.target.style.display = 'none';
 				}}
 			/>

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -48,7 +48,6 @@ export const FlowbiteIllustration = ({
 	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
 
 	return (
-		<div className='text-center' style={containerStyle}>
 			<img 
 				src={illustrationSrc}
 				alt={title || `${name} illustration`}
@@ -59,6 +58,5 @@ export const FlowbiteIllustration = ({
 					e.target.style.display = 'none';
 				}}
 			/>
-		</div>
 	);
 };

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 /**
  * FlowbiteIllustration - Secure SVG illustration component
- * 
+ *
  * Features:
  * - Path traversal protection (sanitizes basePath and name)
  * - Graceful error handling (collapses to 0 height on load failure) and displays nothing
  * - Maintains aspect ratio when height is specified
- * 
+ *
  * Props:
  * @param {string} name - SVG filename (required, alphanumeric/hyphens/underscores only)
  * Available options:
@@ -18,13 +18,13 @@ import React from 'react';
  * @param {string} className - CSS classes for img element
  * @param {string} title - Accessibility title
  * @param {string} basePath - Base directory (default: '/media/illustrations')
- * 
+ *
  * Usage:
  * <FlowbiteIllustration name="unauthorized" className="pb-4" title={t("UnauthorizedAccessScreen|Unauthorized access")}/>
  */
 export const FlowbiteIllustration = ({
 	name,
-	className = '', 
+	className = '',
 	title = '',
 	basePath,
 }) => {
@@ -34,26 +34,28 @@ export const FlowbiteIllustration = ({
 		return null;
 	}
 
-	let path = '/media/illustrations';
+	const sanitize = (basePath, defaultValue) => {
+		if (!basePath) return defaultValue;
 
-	if (basePath) {
-		// Sanitize the basePath to prevent path traversal
-		path = basePath
+		const p = basePath
 			?.replace(/\.\./g, '') // Remove path traversal attempts
 			?.replace(/\/+/g, '/') // Replace multiple slashes with single slash
 			?.replace(/\/$/, ''); // Remove trailing slash
 
-			if (!path) {
-				console.warn(`Invalid base path: '${path}'`);
-				return null;
+			if (!p) {
+				console.warn(`Invalid base path: '${p}', returning defaultValue`);
+				return defaultValue;				
 			}
-	}
 
+			return p;
+	};
+
+	const path = sanitize (basePath, '/media/illustrations');
 
 	const illustrationSrc = `${path}/${name}.svg`;
 
 	return (
-			<img 
+			<img
 				src={illustrationSrc}
 				alt={title || `${name} illustration`}
 				title={title}

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 /**
  * FlowbiteIllustration - Secure SVG illustration component
@@ -10,42 +10,47 @@ import React, { useState } from 'react';
  * 
  * Props:
  * @param {string} name - SVG filename (required, alphanumeric/hyphens/underscores only)
- * currently, we have: [ access, error, invite, unauthorized ]
+ * Available options:
+ * - 'access'
+ * - 'error'
+ * - 'invite'
+ * - 'unauthorized'
  * @param {string} className - CSS classes for img element
  * @param {string} title - Accessibility title
  * @param {string} basePath - Base directory (default: '/media/illustrations')
  * 
  * Usage:
- * <FlowbiteIllustration name="welcome" height="300px" />
+ * <FlowbiteIllustration name="unauthorized" className="pb-4" title={t("UnauthorizedAccessScreen|Unauthorized access")}/>
  */
 export const FlowbiteIllustration = ({
-    name,
-    className = '', 
-    title = '',
-    basePath = '/media/illustrations',
+	name,
+	className = '', 
+	title = '',
+	basePath,
 }) => {
-	// Sanitize the basePath to prevent path traversal
-	const sanitizedBasePath = basePath
-		?.replace(/\.\./g, '') // Remove path traversal attempts
-		?.replace(/\/+/g, '/') // Replace multiple slashes with single slash
-		?.replace(/\/$/, ''); // Remove trailing slash
 
-	if (!sanitizedBasePath) {
-		console.warn(`Invalid base path: '${basePath}'`);
+	if(!name || typeof name !== 'string') {
+		console.warn(`Invalid illustration name: '${name}'`);
 		return null;
 	}
 
-	// Sanitize the name to prevent path traversal and ensure valid filename
-	const sanitizedName = name
-		?.replace(/[^a-zA-Z0-9\-_]/g, '') // Only allow alphanumeric, hyphens, underscores
-		?.toLowerCase();
+	let path = '/media/illustrations';
 
-	if (!sanitizedName) {
-		console.warn(`Invalid or empty illustration name: '${name}'`);
-		return null;
-	}	
+	if (basePath) {
+		// Sanitize the basePath to prevent path traversal
+		path = basePath
+			?.replace(/\.\./g, '') // Remove path traversal attempts
+			?.replace(/\/+/g, '/') // Replace multiple slashes with single slash
+			?.replace(/\/$/, ''); // Remove trailing slash
 
-	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
+			if (!path) {
+				console.warn(`Invalid base path: '${path}'`);
+				return null;
+			}
+	}
+
+
+	const illustrationSrc = `${path}/${name}.svg`;
 
 	return (
 			<img 

--- a/src/components/FlowbiteIllustration.jsx
+++ b/src/components/FlowbiteIllustration.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export const FlowbiteIllustration = ({
 	name,
 	className = '', 
-	width = '300px',
-	height = 'auto',
 	title = '',
 	basePath = '/media/illustrations',
+	height,
 }) => {
+	const [hasError, setHasError] = useState(false);
+
 	// Sanitize the basePath to prevent path traversal
 	const sanitizedBasePath = basePath
 		?.replace(/\.\./g, '') // Remove path traversal attempts
@@ -31,20 +32,22 @@ export const FlowbiteIllustration = ({
 
 	const illustrationSrc = `${basePath}/${sanitizedName}.svg`;
 
+	const containerStyle = hasError ? { height : 0 } : ( height ? { height } : {});
+
 	return (
-		<div className='text-center'>
+		<div className='text-center' style={containerStyle}>
 			<img 
 				src={illustrationSrc}
 				alt={title || `${name} illustration`}
 				title={title}
 				className={className}
 				style={{ 
-					width, 
-					height,
-					maxWidth: '100%',
+					width: '100%',
+					height: '100%',
 				}}
 				onError={(e) => {
 					console.warn(`Illustration '${name}' failed to load from ${illustrationSrc}`);
+					setHasError(true);
 					e.target.style.display = 'none';
 				}}
 			/>

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ export { PubSubProvider, usePubSub } from './components/Context/PubSubContext';
 export { FullscreenButton } from './components/FullscreenButton.jsx';
 export { AttentionBadge } from './components/AttentionRequired/AttentionRequiredBadge.jsx';
 export { RendererWrapper } from './components/RendererWrapper/RendererWrapper.jsx';
+export { FlowbiteIllustration } from './components/FlowbiteIllustration.jsx';
 
 // OBSOLETED COMPONENTS (Aug 2023) - don't use this in a new designs
 export { default as Pagination } from './components/DataTable/Pagination';


### PR DESCRIPTION
Introduced a new illustration component for displaying SVG images with customizable properties.

Updated screens in asab-shell: invalid route, unauthorized access, access control, invitate other user

svgs should be located in:
- lmio-webui/public/media/illustrations
- seacat_admin_webui/public/media/illustrations
- seacat_pki_webui/public/media/illustrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Illustration component to render SVG illustrations by name with props for name, className, title, and optional base path (sanitized).
  * Provides accessible alt/title text, responsive sizing, and hides failed images while logging warnings.

* **Chores**
  * Published as version 26.1.2 and added a changelog entry documenting the new component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->