### PR TITLE
Results Card extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 26.1.7
 
-- Extend functionality for ResultCard to handle more states. Prop `isSuccessful` has been replaced by `status` (`'success' | 'warning' | 'error'`). Fix for ResultCard floating out of the screen. (#46)
-S
+- Extend functionality for ResultCard to handle more states. Prop `isSuccessful` has been replaced by `status` (`'success' | 'warning' | 'danger'`). Fix for ResultCard floating out of the screen. Expanded CopyableInput functionality. (#46)
 
 ## 26.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 25.6.3
+
+- Extend functionality for ResultCard to handle more states (success, error, warning). Fix for ResultCard floating out of the screen (#46)
+
 ## 25.6.2
 
 - Increase defensiveness in DataTable2 when rows are of unsupported type (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG for ASAB WebUI Components
 
-## 26.1.4
+## 26.1.6
 
 - Extend functionality for ResultCard to handle more states. Prop `isSuccessful` has been replaced by `status` (`'success' | 'warning' | 'error'`). Fix for ResultCard floating out of the screen. (#46)
 S

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 25.6.3
 
-- Extend functionality for ResultCard to handle more states (success, error, warning). Fix for ResultCard floating out of the screen (#46)
-
+- Extend functionality for ResultCard to handle more states. Prop `isSuccessful` has been replaced by `status` (`'success' | 'warning' | 'error'`). Fix for ResultCard floating out of the screen. (#46)
+S
 ## 25.6.2
 
 - Increase defensiveness in DataTable2 when rows are of unsupported type (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG for ASAB WebUI Components
 
-## 26.1.9
+## 26.2.1
 
 - Extend functionality for ResultCard to handle more states. Prop `isSuccessful` has been replaced by `status` (`'success' | 'warning' | 'danger'`). Fix for ResultCard floating out of the screen. Expanded CopyableInput functionality. (#46)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.3",
+	"version": "26.1.4",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.8",
+	"version": "26.2.1",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "25.6.2",
+	"version": "25.6.3",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.5",
+	"version": "26.1.6",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/CopyableInput/CopyableInput.js
+++ b/src/components/CopyableInput/CopyableInput.js
@@ -33,13 +33,13 @@ import './CopyableInput.scss';
 			className='my-2'
 		/>
 */
-export const CopyableInput = ({ value, type = 'text', ...props }) => {
+export const CopyableInput = ({ value, type = 'textarea', ...props }) => {
 	const { t } = useTranslation();
 	const [valueCopied, setValueCopied] = useState(false);
 	const timeoutRef = useRef(null);
 
 	// Validate type prop
-	const allowedTypes = ['text', 'email', 'number', 'url', 'tel', 'textarea'];
+	const allowedTypes = ['text', 'textarea'];
 	if (!allowedTypes.includes(type)) {
 		console.warn(`CopyableInput: Invalid type "${type}". Allowed types are: ${allowedTypes.join(', ')}`);
 		return null;

--- a/src/components/CopyableInput/CopyableInput.js
+++ b/src/components/CopyableInput/CopyableInput.js
@@ -12,6 +12,7 @@ import './CopyableInput.scss';
 
 	Props:
 		value: Component value to be displayed and copied
+		type: Input type (default: 'textarea', can be overridden with 'text', etc.)
 		...props: Props to pass to the InputGroup child component
 
 	Usage:
@@ -24,8 +25,15 @@ import './CopyableInput.scss';
 			value={generatedUrl}
 			className='my-2'
 		/>
+		
+		// Or with custom type
+		<CopyableInput
+			value={generatedUrl}
+			type='text'
+			className='my-2'
+		/>
 */
-export const CopyableInput = ({ value, ...props }) => {
+export const CopyableInput = ({ value, type = 'textarea', ...props }) => {
 	const { t } = useTranslation();
 	const [valueCopied, setValueCopied] = useState(false);
 	const timeoutRef = useRef(null);
@@ -59,7 +67,7 @@ export const CopyableInput = ({ value, ...props }) => {
 			<Input 
 				readOnly
 				value={value}
-				type='textarea'
+				type={type}
 				className='asab-copyable-input'
 			/>
 			<Button

--- a/src/components/CopyableInput/CopyableInput.js
+++ b/src/components/CopyableInput/CopyableInput.js
@@ -33,10 +33,17 @@ import './CopyableInput.scss';
 			className='my-2'
 		/>
 */
-export const CopyableInput = ({ value, type = 'textarea', ...props }) => {
+export const CopyableInput = ({ value, type = 'text', ...props }) => {
 	const { t } = useTranslation();
 	const [valueCopied, setValueCopied] = useState(false);
 	const timeoutRef = useRef(null);
+
+	// Validate type prop
+	const allowedTypes = ['text', 'email', 'number', 'url', 'tel', 'textarea'];
+	if (!allowedTypes.includes(type)) {
+		console.warn(`CopyableInput: Invalid type "${type}". Allowed types are: ${allowedTypes.join(', ')}`);
+		return null;
+	}
 
 	useEffect(() => {
 		return () => {

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -12,7 +12,7 @@ export function ResultCard({ body, status = 'success' }) {
 				return 'bi-check-circle-fill text-success';
 			case 'warning':
 				return 'bi-exclamation-circle-fill text-warning';
-			case 'error':
+			case 'danger':
 				return 'bi-exclamation-triangle-fill text-danger';
 			default:
 				return 'bi-check-circle-fill text-success';

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -4,13 +4,26 @@ import { Card, CardBody } from 'reactstrap';
 
 import './ResultCard.scss';
 
-export function ResultCard({ body, isSuccessful = true }) {
+export function ResultCard({ body, status = 'success' }) {
+
+	const getIconAndColor = () => {
+		switch (status) {
+			case 'success':
+				return 'bi-check-circle-fill text-success';
+			case 'warning':
+				return 'bi-cone-striped text-warning';
+			case 'error':
+				return 'bi-exclamation-triangle-fill text-danger';
+			default:
+				return 'bi-check-circle-fill text-success';
+		}
+	};
 
 	return (
 		<Card className='result-card'>
 			<CardBody className='text-center d-flex align-items-center justify-content-center'>
 				<div className='justify-content-center pb-2'>
-					<i className={`pe-2 mb-3 fs-1 bi ${(isSuccessful == true) ? 'bi-check-circle-fill text-success' : 'bi-exclamation-triangle-fill text-danger'}`}></i>
+					<i className={`pe-2 mb-3 fs-1 bi ${getIconAndColor()}`}></i>
 					<div>
 						{body}
 					</div>

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -4,7 +4,7 @@ import { Card, CardBody } from 'reactstrap';
 
 import './ResultCard.scss';
 
-export function ResultCard({ body, status = 'success' }) {
+export function ResultCard({ children, status = 'success' }) {
 
 	const getIconAndColor = () => {
 		switch (status) {
@@ -25,7 +25,7 @@ export function ResultCard({ body, status = 'success' }) {
 				<div className='justify-content-center pb-2 w-75'>
 					<i className={`pe-2 mb-3 fs-1 bi ${getIconAndColor()}`}></i>
 					<div>
-						{body}
+						{children}
 					</div>
 				</div>
 			</CardBody>

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -11,7 +11,7 @@ export function ResultCard({ body, status = 'success' }) {
 			case 'success':
 				return 'bi-check-circle-fill text-success';
 			case 'warning':
-				return 'bi-cone-striped text-warning';
+				return 'bi-exclamation-circle-fill text-warning';
 			case 'error':
 				return 'bi-exclamation-triangle-fill text-danger';
 			default:

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -22,7 +22,7 @@ export function ResultCard({ body, status = 'success' }) {
 	return (
 		<Card className='result-card'>
 			<CardBody className='text-center d-flex align-items-center justify-content-center'>
-				<div className='justify-content-center pb-2'>
+				<div className='justify-content-center pb-2 w-75'>
 					<i className={`pe-2 mb-3 fs-1 bi ${getIconAndColor()}`}></i>
 					<div>
 						{body}

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -4,6 +4,33 @@ import { Card, CardBody } from 'reactstrap';
 
 import './ResultCard.scss';
 
+
+/*
+	Status card component that displays content with an appropriate status icon
+
+	Props:
+		children: Content to be displayed inside the card
+		status: Status type that determines the icon and color (default: 'success')
+			- 'success': Green check circle icon
+			- 'warning': Orange exclamation circle icon
+			- 'dager': Red exclamation triangle icon
+
+	Usage:
+		import { ResultCard } from 'asab_webui_components';
+
+		<ResultCard status='success'>
+			Operation completed successfully!
+		</ResultCard>
+		
+		<ResultCard status='warning'>
+			Warning: Please review the results
+		</ResultCard>
+		
+		<ResultCard status='danger'>
+			An error occurred during processing
+		</ResultCard>
+*/
+
 export function ResultCard({ children, status = 'success' }) {
 
 	const getIconAndColor = () => {

--- a/src/components/ResultCard/ResultCard.scss
+++ b/src/components/ResultCard/ResultCard.scss
@@ -1,8 +1,5 @@
 .result-card {
 	width: 50%;
-	position: absolute;
-	top: 20%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+	margin: 4rem auto 0;
 	border: 1px solid var(--bs-primary);
 }

--- a/src/components/ResultCard/ResultCard.scss
+++ b/src/components/ResultCard/ResultCard.scss
@@ -1,7 +1,7 @@
 .result-card {
 	width: 50%;
 	position: absolute;
-	top: 10%;
+	top: 20%;
 	left: 50%;
 	transform: translate(-50%, -50%);
 	border: 1px solid var(--bs-primary);

--- a/src/index.js
+++ b/src/index.js
@@ -28,10 +28,13 @@ export { problemMarkers } from './utils/monaco/problemMarkers.jsx';
 export { ResultCard } from './components/ResultCard/ResultCard';
 export { AdvancedCard } from './components/AdvancedCard/AdvancedCard.jsx';
 export { AsabReactJson } from './components/AsabReactJson/AsabReactJson.jsx';
-export { PubSubProvider, usePubSub } from './components/Context/PubSubContext';
 export { FullscreenButton } from './components/FullscreenButton.jsx';
 export { AttentionBadge } from './components/AttentionRequired/AttentionRequiredBadge.jsx';
 export { RendererWrapper } from './components/RendererWrapper/RendererWrapper.jsx';
+export { FlowbiteIllustration } from './components/FlowbiteIllustration.jsx';
+export { PubSubProvider, usePubSub } from './components/Context/PubSubContext';
+export { AppStoreProvider, useAppStore, useAppSelector, createAppStore } from './components/Context/store/AppStore.jsx';
+export { registerReducer } from './components/Context/store/reducer/reducerRegistry.jsx';
 
 // OBSOLETED COMPONENTS (Aug 2023) - don't use this in a new designs
 export { default as Pagination } from './components/DataTable/Pagination';


### PR DESCRIPTION
implement results card extension to handle more states (success, error, warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ResultCard now uses a status (success, warning, danger) to determine icon/color and accepts children for content.
  * CopyableInput supports a configurable input type (default: textarea) with validation for allowed types.
* **Bug Fixes**
  * ResultCard layout adjusted to prevent it from floating off-screen and to center with proper spacing.
* **Documentation**
  * Added CHANGELOG entry for release 27.2.1 and bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->