### PR TITLE
Refactor Appstore

### DIFF
--- a/src/components/Context/store/AppStore.jsx
+++ b/src/components/Context/store/AppStore.jsx
@@ -14,6 +14,66 @@ function combineReducers(reducers) {
 		);
 }
 
+/*
+	Method to create app store
+
+	Usage:
+
+	class Application extends Component {
+
+		...
+
+		constructor(props) {
+			super(props);
+
+			// Global AppStore variables
+			this.AppStore = createAppStore();
+
+		...
+
+		<AppStoreProvider app={this}>
+			...
+
+
+	}
+
+	const state = this.App.AppStore.getState();
+	this.App.AppStore.dispatch({type: "myType", payload: ["abc", "def"]})
+*/
+export function createAppStore() {
+	// Get the initial states
+	const initialState = getInitialStates();
+	const rootReducer = (state, action) => {
+		// Get the latest reducers
+		const reducers = getReducers();
+		return combineReducers(reducers)(state, action);
+	};
+
+	return {
+		// State of the store
+		state: initialState,
+		// Listeners for subscriber methods - used for notification if something new is added to the store (dynamic update)
+		listeners: [],
+		// Get the current state
+		getState() {
+			return this.state;
+		},
+		// Update the state by dispatching an action
+		dispatch(action) {
+			this.state = rootReducer(this.state, action);
+			// Notify all subscribers of the action about the update
+			this.listeners.forEach(fn => fn(this.state));
+		},
+		// Subscribe a new listener
+		subscribe(fn) {
+			this.listeners.push(fn);
+			return () => {
+				this.listeners = this.listeners.filter(l => l !== fn);
+			}
+		}
+	};
+}
+
 const AppStoreContext = createContext();
 
 // App store
@@ -21,18 +81,30 @@ export function AppStoreProvider({ children, app }) {
 	// Keep the initial state from the registry at mount
 	const initialState = getInitialStates();
 	// Pulls the current reducer set on every action:
-	const reducerFn = useCallback((state, action) => {
-		return combineReducers(getReducers())(state, action);
-	}, []);
+	const reducerFn = useCallback((state, action) => combineReducers(getReducers())(state, action), []);
 
 	const [state, dispatch] = useReducer(reducerFn, initialState);
 
+	// Wrapped dispatch to update both React state and global AppStore.state
+	const wrappedDispatch = (action) => {
+		// First, dispatch to React reducer
+		dispatch(action);
+
+		// Immediately compute the new state manually
+		// This ensures this.AppStore.state is always in sync
+		const newState = reducerFn(app.AppStore.state, action);
+		app.AppStore.state = newState;
+
+		// Notify listeners (if there is a manual update)
+		app.AppStore.listeners.forEach(fn => fn(newState));
+	};
+
 	// Set the global dispatch and state references
-	app.AppStore.dispatch = dispatch;
-	app.AppStore.state = state;
+	app.AppStore.state = state; // Initial reference
+	app.AppStore.dispatch = wrappedDispatch;
 
 	return (
-		<AppStoreContext.Provider value={{ state, dispatch }}>
+		<AppStoreContext.Provider value={{ state, dispatch: wrappedDispatch }}>
 			{children}
 		</AppStoreContext.Provider>
 	);

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export { FullscreenButton } from './components/FullscreenButton.jsx';
 export { AttentionBadge } from './components/AttentionRequired/AttentionRequiredBadge.jsx';
 export { RendererWrapper } from './components/RendererWrapper/RendererWrapper.jsx';
 export { PubSubProvider, usePubSub } from './components/Context/PubSubContext';
-export { AppStoreProvider, useAppStore, useAppSelector } from './components/Context/store/AppStore.jsx';
+export { AppStoreProvider, useAppStore, useAppSelector, createAppStore } from './components/Context/store/AppStore.jsx';
 export { registerReducer } from './components/Context/store/reducer/reducerRegistry.jsx';
 
 // OBSOLETED COMPONENTS (Aug 2023) - don't use this in a new designs

--- a/src/seacat-auth/components/Credentials/Credentials.js
+++ b/src/seacat-auth/components/Credentials/Credentials.js
@@ -20,7 +20,7 @@ export function Credentials({ app, credentials_id, cleanupTime = 1000 * 60 * 60 
 		return '';
 	}
 
-	const resources = app.AppStore?.state?.auth?.resources || [];
+	const resources = app.AppStore?.getState()?.auth?.resources || [];
 	const resource = 'seacat:credentials:access'; // Resource required to access the Credentials List Screen
 
 	// Validation on props.app

--- a/src/seacat-auth/utils/isAuthorized.js
+++ b/src/seacat-auth/utils/isAuthorized.js
@@ -15,6 +15,6 @@ Usage:
 */
 
 export function isAuthorized(resourcesArray, app) {
-	const resources = app?.AppStore?.state?.auth?.resources || [];
+	const resources = app?.AppStore?.getState()?.auth?.resources || [];
 	return resources.includes('authz:superuser') || resourcesArray.some(resource => resources.includes(resource));
 }


### PR DESCRIPTION
# Refactor appstore

## Issue

- the appstore did not updated its state dynamically, causing some random misusage usually on Safari browsers

## Fix

- add a dynamic appstore variables which are updated dynamically, striping off the issue described above
- created a initial createAppStore method (similar to redux) with defined global variables