### PR TITLE
Bugfix/on initial state in appstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.3",
+	"version": "26.1.4",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/Context/store/AppStore.jsx
+++ b/src/components/Context/store/AppStore.jsx
@@ -78,12 +78,10 @@ const AppStoreContext = createContext();
 
 // App store
 export function AppStoreProvider({ children, app }) {
-	// Keep the initial state from the registry at mount
-	const initialState = getInitialStates();
 	// Pulls the current reducer set on every action:
 	const reducerFn = useCallback((state, action) => combineReducers(getReducers())(state, action), []);
 
-	const [state, dispatch] = useReducer(reducerFn, initialState);
+	const [state, dispatch] = useReducer(reducerFn, app.AppStore.state);
 
 	// Wrapped dispatch to update both React state and global AppStore.state
 	const wrappedDispatch = (action) => {


### PR DESCRIPTION
# Bugfix

- Fix on initialState declared 2 within app store initialization, (once in createAppStore and second time in AppStoreProvider) causing overriding the dynamically added reducer state with the initial state