### PR TITLE
Upgrade to react-router v7

### DIFF
--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.10.0]
+        node-version: [22.18.0]
 
     steps:
     - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.1.1
+
+- Upgrade to react router v7, upgrade other "out of date" dependencies (#52)
+
 ## 26.1.8
 
 - Implement new `DataTableAdvCustomFilter` with `CustomPill` feature for `DataTable2` (#38)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@babel/preset-react": "^7.22.5",
 		"babel-plugin-module-resolver": "^5.0.2",
 		"copyfiles": "^2.4.1",
-		"rimraf": "^5.0.0"
+		"rimraf": "^6.0.1"
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.22.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.8",
+	"version": "26.2.1",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 		"react-dom": "^19.0.0",
 		"react-i18next": "^11.8.12",
 		"@microlink/react-json-view": "^1.26.2",
-		"react-router": "^6.16.0",
-		"react-router-dom": "^6.16.0",
+		"react-router": "^7.8.2",
 		"reactstrap": "^9.2.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
 		"bootstrap": "^5.3.1",
 		"bootstrap-icons": "^1.10.5",
 		"date-fns": "^2.30.0",
-		"i18next": "^20.3.5",
+		"i18next": "^25.4.2",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
-		"react-i18next": "^11.8.12",
+		"react-i18next": "^15.7.3",
 		"@microlink/react-json-view": "^1.26.2",
 		"react-router": "^7.8.2",
 		"reactstrap": "^9.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.2.1",
+	"version": "27.1.1",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"axios": "^1.8.4",
 		"bootstrap": "^5.3.1",
 		"bootstrap-icons": "^1.10.5",
-		"date-fns": "^2.30.0",
+		"date-fns": "^4.1.0",
 		"i18next": "^25.4.2",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",

--- a/src/components/DataTable/Buttons.js
+++ b/src/components/DataTable/Buttons.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { format } from 'date-fns';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
 	Button, Dropdown, DropdownToggle, DropdownMenu, DropdownItem
 } from 'reactstrap';

--- a/src/components/DataTable/Table.js
+++ b/src/components/DataTable/Table.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import ReactJsonView from '@microlink/react-json-view'
 import { Table } from 'reactstrap';

--- a/src/components/DataTable2/DataTableContext.jsx
+++ b/src/components/DataTable2/DataTableContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useMemo, useState, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { updateLimit, updateStateLimit } from './components/utils/updateTableLimit.jsx';
 

--- a/src/components/DateTime/utils/useDateFNSLocale.js
+++ b/src/components/DateTime/utils/useDateFNSLocale.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAppSelector } from '../../Context/store/AppStore.jsx';
-import cs from 'date-fns/locale/cs'; // (possible exports: af, ar, arDZ, arEG, arMA, arSA, arTN, az, be, beTarask, bg, bn, bs, ca, cs, cy, da, de, deAT, el, enAU, enCA, enGB, enIE, enIN, enNZ, enUS, enZA, eo, es, et, eu, faIR, fi, fr, frCA, frCH, fy, gd, gl, gu, he, hi, hr, ht, hu, hy, id, is, it, itCH, ja, jaHira, ka, kk, km, kn, ko, lb, lt, lv, mk, mn, ms, mt, nb, nl, nlBE, nn, oc, pl, pt, ptBR, ro, ru, sk, sl, sq, sr, srLatn, sv, ta, te, th, tr, ug, uk, uz, uzCyrl, vi, zhCN, zhHK, zhTW)
+import { cs } from 'date-fns/locale/cs'; // (possible exports: af, ar, arDZ, arEG, arMA, arSA, arTN, az, be, beTarask, bg, bn, bs, ca, cs, cy, da, de, deAT, el, enAU, enCA, enGB, enIE, enIN, enNZ, enUS, enZA, eo, es, et, eu, faIR, fi, fr, frCA, frCH, fy, gd, gl, gu, he, hi, hr, ht, hu, hy, id, is, it, itCH, ja, jaHira, ka, kk, km, kn, ko, lb, lt, lv, mk, mn, ms, mt, nb, nl, nlBE, nn, oc, pl, pt, ptBR, ro, ru, sk, sl, sq, sr, srLatn, sv, ta, te, th, tr, ug, uk, uz, uzCyrl, vi, zhCN, zhHK, zhTW)
 
 /*
 	To bundle the locales and avoid bundle size issues, we need to define the specific locales used.

--- a/src/seacat-auth/components/LinkWithAuthz.js
+++ b/src/seacat-auth/components/LinkWithAuthz.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { authz } from '../utils/authz';
 
 


### PR DESCRIPTION
- upgraded to react router v7
- upgraded to latest i18n libraries
- upgraded to date-fns v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Bumped package version to 27.1.1.
  - Updated peer dependencies to newer major versions (date-fns v4, i18next v25, react-i18next v15, react-router v7) and removed react-router-dom peer.
  - CI now runs on Node.js 22.
  - Added CHANGELOG entry for 27.1.1.

- Refactor
  - Consolidated routing usage to react-router for links and search params.
  - Updated date-fns locale import style.

Note: Consumers may need to align their installed peer dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->