### PR TITLE
update Datetime - handle bigint as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 26.1.7
+
+- Extended the condition for DateTime in `validateDateTime`, whether the string is bigint. (#53)
+
 ## 26.1.6
 
 - Add `CopyableInput` component (#49)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "26.1.6",
+	"version": "26.1.7",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DateTime/utils/validateDateTime.jsx
+++ b/src/components/DateTime/utils/validateDateTime.jsx
@@ -12,10 +12,11 @@ export function validateDateTime(value) {
 
 	// Handle string values
 	if (typeof value === 'string') {
-		// If the string consists of only digits and the length is greater than or equal to 17, interpret it as a BigInt
-		if (/^\d+$/.test(value) && (value.length >= 17)) {
+		// If the string consists of only digits with optional 'n' at the end string ends with `n`
+		if (/^\d+n?$/.test(value) && value.endsWith('n')) {
 			try {
-				return splDatetimeToIso(BigInt(value));
+				// Remove the 'n' suffix before converting to BigInt
+				return splDatetimeToIso(BigInt(value.slice(0, -1)));
 			} catch {
 				return 'Invalid Date';
 			}

--- a/src/components/DateTime/utils/validateDateTime.jsx
+++ b/src/components/DateTime/utils/validateDateTime.jsx
@@ -12,6 +12,14 @@ export function validateDateTime(value) {
 
 	// Handle string values
 	if (typeof value === 'string') {
+		// If the string consists of only digits and the length is greater than or equal to 17, interpret it as a BigInt
+		if (/^\d+$/.test(value) && (value.length >= 17)) {
+			try {
+				return splDatetimeToIso(BigInt(value));
+			} catch {
+				return 'Invalid Date';
+			}
+		}
 		return new Date(value);
 	}
 

--- a/src/components/DateTime/utils/validateDateTime.jsx
+++ b/src/components/DateTime/utils/validateDateTime.jsx
@@ -1,3 +1,6 @@
+// For best performance, create a regular expression only once.
+const n_digits = /^\d+n$/;
+
 export function validateDateTime(value) {
 	// Return 'Invalid Date' if the input is null or undefined
 	if (value == null) {
@@ -13,7 +16,7 @@ export function validateDateTime(value) {
 	// Handle string values
 	if (typeof value === 'string') {
 		// Check if string ends with 'n' AND verify the entire string consists only of digits followed by 'n'
-		if (value.endsWith('n') && /^\d+n$/.test(value)) {
+		if (value.endsWith('n') && n_digits.test(value)) {
 			try {
 				// Remove the 'n' suffix before converting to BigInt
 				return splDatetimeToIso(BigInt(value.slice(0, -1)));

--- a/src/components/DateTime/utils/validateDateTime.jsx
+++ b/src/components/DateTime/utils/validateDateTime.jsx
@@ -12,8 +12,8 @@ export function validateDateTime(value) {
 
 	// Handle string values
 	if (typeof value === 'string') {
-		// If the string consists of only digits with optional 'n' at the end string ends with `n`
-		if (/^\d+n?$/.test(value) && value.endsWith('n')) {
+		// Check if string ends with 'n' AND verify the entire string consists only of digits followed by 'n'
+		if (value.endsWith('n') && /^\d+n$/.test(value)) {
 			try {
 				// Remove the 'n' suffix before converting to BigInt
 				return splDatetimeToIso(BigInt(value.slice(0, -1)));


### PR DESCRIPTION
on the parser screen, it was decided to send bigint as a string after the discussion. Update the DateTime component so that it handle this on the date. It returns an Invalid date
- added a check that checks if the string is a bigint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DateTime validation to correctly handle bigint-like strings (e.g., values ending with “n”), preventing invalid date results in those cases.

* **Documentation**
  * Updated changelog with details for version 26.1.7.

* **Chores**
  * Bumped package version to 26.1.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->