### PR TITLE
Update authz components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.5
+
+- Allowed to pass `resource` prop as an array or as a string for LinkWithAuthz, ButtonWithAuthz, UncontrolledSwitchWithAuthz and ControlledSwitchWithAuthz. (#63)
+
 ## 27.3.4
 
 - Add optional `className` prop to `DataTable2` to support Card Fullscreen functionality (#61)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.4",
+	"version": "27.3.5",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/seacat-auth/components/ButtonWithAuthz.js
+++ b/src/seacat-auth/components/ButtonWithAuthz.js
@@ -56,11 +56,7 @@ import { authz } from '../utils/authz';
 
 export function ButtonWithAuthz(props) {
 	let childProps = {...props}; // Create a new child component to have option to remove props
-	let authzObj = authz(childProps);
-
-	const disabled = authzObj.disabled;
-	const hide = authzObj.hide;
-	const title = authzObj.title;
+	const { disabled, title, hide } = authz(childProps);
 
 	return (
 		hide && disabled ? null :

--- a/src/seacat-auth/components/LinkWithAuthz.js
+++ b/src/seacat-auth/components/LinkWithAuthz.js
@@ -46,7 +46,7 @@ export function LinkWithAuthz(props) {
 	return (
 		disabled ?
 			<span title={title} {...childProps}>{childProps.children}</span>
-			:
+		:
 			<Link {...childProps}>{childProps.children}</Link>
 	)
 }

--- a/src/seacat-auth/components/LinkWithAuthz.js
+++ b/src/seacat-auth/components/LinkWithAuthz.js
@@ -43,13 +43,10 @@ export function LinkWithAuthz(props) {
 	const childProps = { ...props };
 	const { disabled, title } = authz(childProps);
 
-	return disabled ? (
-		<span title={title} {...childProps}>
-			{childProps.children}
-		</span>
-	) : (
-		<Link {...childProps}>
-			{childProps.children}
-		</Link>
-	);
+	return (
+		disabled ?
+			<span title={title} {...childProps}>{childProps.children}</span>
+			:
+			<Link {...childProps}>{childProps.children}</Link>
+	)
 }

--- a/src/seacat-auth/components/LinkWithAuthz.js
+++ b/src/seacat-auth/components/LinkWithAuthz.js
@@ -40,15 +40,16 @@ import { authz } from '../utils/authz';
 */
 
 export function LinkWithAuthz(props) {
-	let childProps = {...props};
-	let authzObj = authz(childProps);
-	const disabled = authzObj.disabled;
-	const title = authzObj.title;
+	const childProps = { ...props };
+	const { disabled, title } = authz(childProps);
 
-	return (
-		disabled ? 
-			<span title={title} {...childProps}>{childProps.children}</span>
-		:
-			<Link {...childProps}>{childProps.children}</Link>
-	)
+	return disabled ? (
+		<span title={title} {...childProps}>
+			{childProps.children}
+		</span>
+	) : (
+		<Link {...childProps}>
+			{childProps.children}
+		</Link>
+	);
 }

--- a/src/seacat-auth/components/Switches/ControlledSwitchWithAuthz.js
+++ b/src/seacat-auth/components/Switches/ControlledSwitchWithAuthz.js
@@ -53,11 +53,7 @@ import { ControlledSwitch } from './utils/ControlledSwitch/ControlledSwitch';
 
 export function ControlledSwitchWithAuthz(props) {
 	let childProps = {...props}; // Create a new child component to have option to remove props
-	let authzObj = authz(childProps);
-
-	const disabled = authzObj.disabled;
-	const hide = authzObj.hide;
-	const title = authzObj.title;
+	const { disabled, title, hide } = authz(childProps);
 
 	return (
 		hide && disabled ? null :

--- a/src/seacat-auth/components/Switches/UncontrolledSwitchWithAuthz.js
+++ b/src/seacat-auth/components/Switches/UncontrolledSwitchWithAuthz.js
@@ -54,11 +54,7 @@ import { UncontrolledSwitch } from './utils/UncontrolledSwitch';
 
 export function UncontrolledSwitchWithAuthz(props) {
 	let childProps = {...props}; // Create a new child component to have option to remove props
-	let authzObj = authz(childProps);
-
-	const disabled = authzObj.disabled;
-	const hide = authzObj.hide;
-	const title = authzObj.title;
+	const { disabled, title, hide } = authz(childProps);
 
 	return (
 		hide && disabled ? null :

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -20,6 +20,11 @@ export const authz = (childProps) => {
 		}
 	}
 
+	// Respect explicit disabled prop passed by developer
+	if (disabledProp === true) {
+		disabled = true;
+	}
+
 	// Determine if the element should be hidden when unauthorized
 	const hide = Boolean(hideOnUnauthorizedAccess);
 	// Remove prop to avoid React warnings about unknown attributes
@@ -31,11 +36,6 @@ export const authz = (childProps) => {
 	let title = titleProp;
 	if (disabled) {
 		title = t('General|You do not have access rights to perform this action');
-	}
-
-	// Respect explicit disabled prop passed by developer
-	if (disabledProp === true) {
-		disabled = true;
 	}
 
 	return { disabled, hide, title };

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -13,11 +13,9 @@ export const authz = (childProps) => {
 
 	// Check if the user has at least one of the required resources. Also, if user has 'authz:superuser', always allow
 	if (resources) {
-		if (resources.includes('authz:superuser')) {
-			disabled = false;
-		} else {
-			disabled = !requiredResources.some(r => resources.includes(r));
-		}
+		const isSuperUser = resources?.includes('authz:superuser');
+		const hasRequiredResource = requiredResources.some(r => resources?.includes(r));
+		disabled = !(isSuperUser || hasRequiredResource);
 	}
 
 	// Respect explicit disabled prop passed by developer

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -1,27 +1,42 @@
 import { useTranslation } from 'react-i18next';
-// Used for Button and Switches with authz
-export const authz = (childProps) => {
-	const { t, i18n } = useTranslation();
 
-	let disabled = childProps.resources && childProps.resource ? childProps.resources.indexOf(childProps.resource) === -1 : true;
-	// If user is superuser, then button is enabled
-	if (childProps.resources && childProps.resources.indexOf('authz:superuser') !== -1) {
-		disabled = false;
+// Used for Button, Link and Switches with authz
+export const authz = (childProps) => {
+	const { t } = useTranslation();
+
+	const { resource, resources, hideOnUnauthorizedAccess, disabled: disabledProp, title: titleProp } = childProps;
+
+	let disabled = true;
+
+	// Normalize `resource` to array for uniform handling
+	const requiredResources = resource ? (Array.isArray(resource) ? resource : [resource]) : [];
+
+	// Check if the user has at least one of the required resources. Also, if user has 'authz:superuser', always allow
+	if (resources) {
+		if (resources.includes('authz:superuser')) {
+			disabled = false;
+		} else {
+			disabled = !requiredResources.some(r => resources.includes(r));
+		}
 	}
-	// If defined, hide the disabled button
-	let hide = childProps.hideOnUnauthorizedAccess ? true : false;
-	// Remove hideOnUnauthorized element from props to avoid react warnings
-	if (childProps.hideOnUnauthorizedAccess) {
-		delete childProps["hideOnUnauthorizedAccess"];
+
+	// Determine if the element should be hidden when unauthorized
+	const hide = Boolean(hideOnUnauthorizedAccess);
+	// Remove prop to avoid React warnings about unknown attributes
+	if (hideOnUnauthorizedAccess) {
+		delete childProps.hideOnUnauthorizedAccess;
 	}
-	let title = childProps.title;
-	// Check on title eventually passed in the props
+
+	// Set the title for unauthorized state
+	let title = titleProp;
 	if (disabled) {
-		 title = t("General|You do not have access rights to perform this action");
+		title = t('General|You do not have access rights to perform this action');
 	}
-	// Check on disabled eventually passed in the props
-	if (childProps.disabled && disabled == false) {
-		disabled = childProps.disabled;
+
+	// Respect explicit disabled prop passed by developer
+	if (disabledProp === true) {
+		disabled = true;
 	}
-	return {disabled: disabled, hide: hide, title: title};
+
+	return { disabled, hide, title };
 }

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -21,7 +21,8 @@ export const authz = (childProps) => {
 		disabled = false;
 	} else {
 		// if at least one match is found — access is granted
-		disabled = !requiredResources.some((r) => resources?.includes(r));
+		const resourcesSet = new Set(resources);
+		disabled = !requiredResources.some(r => resourcesSet.has(r));
 	}
 
 	// If defined, hide the disabled button

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
-
-// Used for Button, Link and Switches with authz
+// Used for Button and Switches with authz
 export const authz = (childProps) => {
 	const { t } = useTranslation();
 
@@ -15,16 +14,14 @@ export const authz = (childProps) => {
 	let disabled = true;
 
 	// Check if the user has at least one of the required resources. Also, if user has 'authz:superuser', always allow
-	if (Array.isArray(resources) && resource) {
-		const requiredResources = Array.isArray(resource) ? resource : [resource];
+	const requiredResources = Array.isArray(resource) ? resource : [resource];
 
-		// superuser always allow
-		if (resources.includes('authz:superuser')) {
-			disabled = false;
-		} else {
-			// if at least one match is found — access is granted
-			disabled = !requiredResources.some((r) => resources.includes(r));
-		}
+	// superuser always allow
+	if (resources?.includes('authz:superuser')) {
+		disabled = false;
+	} else {
+		// if at least one match is found — access is granted
+		disabled = !requiredResources.some((r) => resources?.includes(r));
 	}
 
 	// If defined, hide the disabled button

--- a/src/seacat-auth/utils/authz.js
+++ b/src/seacat-auth/utils/authz.js
@@ -4,28 +4,33 @@ import { useTranslation } from 'react-i18next';
 export const authz = (childProps) => {
 	const { t } = useTranslation();
 
-	const { resource, resources, hideOnUnauthorizedAccess, disabled: disabledProp, title: titleProp } = childProps;
+	const {
+		resources,
+		resource,
+		hideOnUnauthorizedAccess,
+		disabled: disabledProp,
+		title: titleProp,
+	} = childProps;
 
 	let disabled = true;
 
-	// Normalize `resource` to array for uniform handling
-	const requiredResources = resource ? (Array.isArray(resource) ? resource : [resource]) : [];
-
 	// Check if the user has at least one of the required resources. Also, if user has 'authz:superuser', always allow
-	if (resources) {
-		const isSuperUser = resources?.includes('authz:superuser');
-		const hasRequiredResource = requiredResources.some(r => resources?.includes(r));
-		disabled = !(isSuperUser || hasRequiredResource);
+	if (Array.isArray(resources) && resource) {
+		const requiredResources = Array.isArray(resource) ? resource : [resource];
+
+		// superuser always allow
+		if (resources.includes('authz:superuser')) {
+			disabled = false;
+		} else {
+			// if at least one match is found — access is granted
+			disabled = !requiredResources.some((r) => resources.includes(r));
+		}
 	}
 
-	// Respect explicit disabled prop passed by developer
-	if (disabledProp === true) {
-		disabled = true;
-	}
-
-	// Determine if the element should be hidden when unauthorized
+	// If defined, hide the disabled button
 	const hide = Boolean(hideOnUnauthorizedAccess);
-	// Remove prop to avoid React warnings about unknown attributes
+
+	// Remove hideOnUnauthorized element from props to avoid react warnings
 	if (hideOnUnauthorizedAccess) {
 		delete childProps.hideOnUnauthorizedAccess;
 	}
@@ -36,5 +41,10 @@ export const authz = (childProps) => {
 		title = t('General|You do not have access rights to perform this action');
 	}
 
+	// Check on disabled eventually passed in the props
+	if (disabledProp && (disabled === false)) {
+		disabled = disabledProp;
+	}
+
 	return { disabled, hide, title };
-}
+};


### PR DESCRIPTION
Allowed to pass `resource` prop as an array or as a string for LinkWithAuthz, ButtonWithAuthz, UncontrolledSwitchWithAuthz and ControlledSwitchWithAuthz.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified authorization handling inside UI components for clearer, more maintainable code.

* **Updates**
  * Authorization utility now accepts single or multiple resources, supports a superuser override, and honors hide-on-unauthorized behavior.
  * External disabled and title props are respected; disabled state and access-denied titles are handled consistently.

* **Chores**
  * Release bumped to 27.3.5 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->