### PR TITLE
update DataTableSort2, add sortDirection prop for DataTableSort2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.6
+
+- Add `defaultSortDirection` prop for DataTable2. Allows to start sorting with descend (#66)
+
 ## 27.3.5
 
 - Allowed to pass `resource` prop as an array or as a string for LinkWithAuthz, ButtonWithAuthz, UncontrolledSwitchWithAuthz and ControlledSwitchWithAuthz. (#63)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.7
+
+- Add `sortDirection` prop for DataTable2 for Columns sorting. Update docs for DataTable2 (#66)
+
 ## 27.3.6
 
 - Set `escapeValues` to `true` in ErrorHandler translation util component to prevent potential XSS attacks. (#67)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.6",
+	"version": "27.3.7",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.7",
+	"version": "27.3.8",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.5",
+	"version": "27.3.6",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -14,7 +14,7 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 import './DataTable2.scss';
 
 // Wrapper for datatable context
-export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle, defaultSortDirection }) {
+export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -26,14 +26,13 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 				rowHeight={rowHeight}
 				rowStyle={rowStyle}
 				hideFooter={hideFooter}
-				defaultSortDirection={defaultSortDirection}
 			/>
 		</DataTableContextProvider>
 	);
 }
 
 
-function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter, defaultSortDirection }) {
+function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
 	// Getting application object and PubSub subscription
 	const { app, subscribe } = usePubSub();
 	const { watchParams, getParam, setParams, serializeParams } = useDataTableContext();
@@ -191,7 +190,6 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 				<DataTableCardPill2 isLoading={isLoading} rowHeight={rowHeight}/>
 				{isLoading
 					? <DataTable2
-						defaultSortDirection={defaultSortDirection}
 						columns={columns}
 						rows={Array(getParam('i') ? getParam('i') : 10).fill({})} // Simulate rows
 						limit={getParam('i')}
@@ -200,7 +198,6 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 						rowStyle={rowStyle}
 					/>
 					: <DataTable2
-						defaultSortDirection={defaultSortDirection}
 						columns={columns}
 						rows={rows}
 						limit={getParam('i')}
@@ -293,7 +290,7 @@ export function DataTableCardFooter2({page, limit, count, rows, isLoading}) {
 }
 
 
-export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, defaultSortDirection}) {
+export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle}) {
 	return (
 		<Table className="datatable2 placeholder-glow">
 			<colgroup>
@@ -308,9 +305,9 @@ export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, 
 						<th key={idx} style={column?.thStyle} className="pt-0" id={`datatable-column-${idx}`}>
 							{column?.sort ?
 								<DataTableSort2
-									defaultSortDirection={defaultSortDirection}
 									title={column?.title}
 									field={column.sort}
+									sortDirection={column?.sortDirection}
 								/>
 							: column?.title}
 						</th>
@@ -435,18 +432,19 @@ function DataTableBadge({ item, value, isLoading, onRemove }) {
 }
 
 // Inner sorting function
-function DataTableSort2({ title, field, defaultSortDirection = 'a' }) {
+function DataTableSort2({title, field, sortDirection = 'a'}) {
 	const { onTriggerSort, getParam } = useDataTableContext();
 	const { t } = useTranslation();
 
 	// Get the current sorting direction for this field from URL/search params (e.g. 'a' or 'd')
 	const currentDirection = getParam(`s${field}`);
+	console.log(currentDirection);
 
 	// Determine what the next sorting direction should be after click
 	const getNextDirection = () => {
 		// If the column is not currently sorted, use the provided default direction (e.g. 'a' or 'd')
 		if (!currentDirection) {
-			return defaultSortDirection;
+			return sortDirection;
 		}
 
 		// If currently descending ('d'), switch to ascending ('a'), otherwise switch to descending

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -452,7 +452,7 @@ function DataTableSort2({title, field, sortDirection}) {
 
 	return (
 		currentSort ?
-			(currentSort == 'd') ?
+			(currentSort === 'd') ?
 				<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, 'a')}>
 					{title}
 					<i
@@ -460,7 +460,7 @@ function DataTableSort2({title, field, sortDirection}) {
 						className='bi bi-sort-up sort-icon-active ms-2'
 					></i>
 				</span>
-				:
+			:
 				<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, 'd')}>
 					{title}
 					<i

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -439,15 +439,21 @@ function DataTableSort2({ title, field, defaultDirection = 'a' }) {
 	const { onTriggerSort, getParam } = useDataTableContext();
 	const { t } = useTranslation();
 
+	// Get the current sorting direction for this field from URL/search params (e.g. 'a' or 'd')
 	const currentDirection = getParam(`s${field}`);
 
+	// Determine what the next sorting direction should be after click
 	const getNextDirection = () => {
+		// If the column is not currently sorted, use the provided default direction (e.g. 'a' or 'd')
 		if (!currentDirection) {
 			return defaultDirection;
 		}
+
+		// If currently descending ('d'), switch to ascending ('a'), otherwise switch to descending
 		return currentDirection === 'd' ? 'a' : 'd';
 	};
 
+	// Calculate the next direction that will be applied on click
 	const nextDirection = getNextDirection();
 
 	return (

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -14,7 +14,7 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 import './DataTable2.scss';
 
 // Wrapper for datatable context
-export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle, defaultDirection }) {
+export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle, defaultSortDirection }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -26,14 +26,14 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 				rowHeight={rowHeight}
 				rowStyle={rowStyle}
 				hideFooter={hideFooter}
-				defaultDirection={defaultDirection}
+				defaultSortDirection={defaultSortDirection}
 			/>
 		</DataTableContextProvider>
 	);
 }
 
 
-function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter, defaultDirection }) {
+function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter, defaultSortDirection }) {
 	// Getting application object and PubSub subscription
 	const { app, subscribe } = usePubSub();
 	const { watchParams, getParam, setParams, serializeParams } = useDataTableContext();
@@ -191,7 +191,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 				<DataTableCardPill2 isLoading={isLoading} rowHeight={rowHeight}/>
 				{isLoading
 					? <DataTable2
-						defaultDirection={defaultDirection}
+						defaultSortDirection={defaultSortDirection}
 						columns={columns}
 						rows={Array(getParam('i') ? getParam('i') : 10).fill({})} // Simulate rows
 						limit={getParam('i')}
@@ -200,7 +200,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 						rowStyle={rowStyle}
 					/>
 					: <DataTable2
-						defaultDirection={defaultDirection}
+						defaultSortDirection={defaultSortDirection}
 						columns={columns}
 						rows={rows}
 						limit={getParam('i')}
@@ -293,7 +293,7 @@ export function DataTableCardFooter2({page, limit, count, rows, isLoading}) {
 }
 
 
-export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, defaultDirection}) {
+export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, defaultSortDirection}) {
 	return (
 		<Table className="datatable2 placeholder-glow">
 			<colgroup>
@@ -308,7 +308,7 @@ export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, 
 						<th key={idx} style={column?.thStyle} className="pt-0" id={`datatable-column-${idx}`}>
 							{column?.sort ?
 								<DataTableSort2
-									defaultDirection={defaultDirection}
+									defaultSortDirection={defaultSortDirection}
 									title={column?.title}
 									field={column.sort}
 								/>
@@ -435,7 +435,7 @@ function DataTableBadge({ item, value, isLoading, onRemove }) {
 }
 
 // Inner sorting function
-function DataTableSort2({ title, field, defaultDirection = 'a' }) {
+function DataTableSort2({ title, field, defaultSortDirection = 'a' }) {
 	const { onTriggerSort, getParam } = useDataTableContext();
 	const { t } = useTranslation();
 
@@ -446,7 +446,7 @@ function DataTableSort2({ title, field, defaultDirection = 'a' }) {
 	const getNextDirection = () => {
 		// If the column is not currently sorted, use the provided default direction (e.g. 'a' or 'd')
 		if (!currentDirection) {
-			return defaultDirection;
+			return defaultSortDirection;
 		}
 
 		// If currently descending ('d'), switch to ascending ('a'), otherwise switch to descending

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -458,7 +458,7 @@ function DataTableSort2({title, field, sortDirection}) {
 					<i
 						title={`${t('General|Sort ascend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
 						className='bi bi-sort-up sort-icon-active ms-2'
-					></i>
+					/>
 				</span>
 			:
 				<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, 'd')}>
@@ -466,15 +466,15 @@ function DataTableSort2({title, field, sortDirection}) {
 					<i
 						title={`${t('General|Sort descend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
 						className='bi bi-sort-down-alt sort-icon-active ms-2'
-					></i>
+					/>
 				</span>
 		:
 			<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, getInitialSortDirection())}>
-					{title}
+				{title}
 				<i
 					title={t('General|Shift + left mouse click for advanced sorting')}
 					className='bi bi-arrow-down-up ms-2'
-				></i>
-				</span>
+				/>
+			</span>
 	);
 }

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -432,55 +432,49 @@ function DataTableBadge({ item, value, isLoading, onRemove }) {
 }
 
 // Inner sorting function
-function DataTableSort2({title, field, sortDirection = 'a'}) {
+function DataTableSort2({title, field, sortDirection}) {
 	const { onTriggerSort, getParam } = useDataTableContext();
 	const { t } = useTranslation();
 
 	// Get the current sorting direction for this field from URL/search params (e.g. 'a' or 'd')
-	const currentDirection = getParam(`s${field}`);
-	console.log(currentDirection);
+	const currentSort = getParam(`s${field}`);
 
-	// Determine what the next sorting direction should be after click
-	const getNextDirection = () => {
-		// If the column is not currently sorted, use the provided default direction (e.g. 'a' or 'd')
-		if (!currentDirection) {
+	// Determine what the start sorting direction should be after click
+	const getInitialSortDirection = () => {
+		if (sortDirection && !currentSort) {
+			// If there is a SortDirection and the field is not sorted yet, we use SortDirection
 			return sortDirection;
 		}
 
-		// If currently descending ('d'), switch to ascending ('a'), otherwise switch to descending
-		return currentDirection === 'd' ? 'a' : 'd';
+		// Otherwise standard behavior (sorted in ascending order)
+		return 'a';
 	};
 
-	// Calculate the next direction that will be applied on click
-	const nextDirection = getNextDirection();
-
 	return (
-		<span
-			className='sort-span-wrapper'
-			onClick={(e) => onTriggerSort(e, field, nextDirection)}
-		>
-      		{title}
-
-			{currentDirection === 'd' && (
-				<i
-					title={`${t('General|Sort ascend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
-					className='bi bi-sort-up sort-icon-active ms-2'
-				/>
-			)}
-
-			{currentDirection === 'a' && (
-				<i
-					title={`${t('General|Sort descend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
-					className='bi bi-sort-down-alt sort-icon-active ms-2'
-				/>
-			)}
-
-			{!currentDirection && (
+		currentSort ?
+			(currentSort == 'd') ?
+				<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, 'a')}>
+					{title}
+					<i
+						title={`${t('General|Sort ascend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
+						className='bi bi-sort-up sort-icon-active ms-2'
+					></i>
+				</span>
+				:
+				<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, 'd')}>
+					{title}
+					<i
+						title={`${t('General|Sort descend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
+						className='bi bi-sort-down-alt sort-icon-active ms-2'
+					></i>
+				</span>
+		:
+			<span className='sort-span-wrapper' onClick={(e) => onTriggerSort(e, field, getInitialSortDirection())}>
+					{title}
 				<i
 					title={t('General|Shift + left mouse click for advanced sorting')}
 					className='bi bi-arrow-down-up ms-2'
-				/>
-			)}
-    </span>
+				></i>
+				</span>
 	);
 }

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -14,7 +14,7 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 import './DataTable2.scss';
 
 // Wrapper for datatable context
-export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle }) {
+export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle, defaultDirection }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -26,13 +26,14 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 				rowHeight={rowHeight}
 				rowStyle={rowStyle}
 				hideFooter={hideFooter}
+				defaultDirection={defaultDirection}
 			/>
 		</DataTableContextProvider>
 	);
 }
 
 
-function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
+function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter, defaultDirection }) {
 	// Getting application object and PubSub subscription
 	const { app, subscribe } = usePubSub();
 	const { watchParams, getParam, setParams, serializeParams } = useDataTableContext();
@@ -190,6 +191,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 				<DataTableCardPill2 isLoading={isLoading} rowHeight={rowHeight}/>
 				{isLoading
 					? <DataTable2
+						defaultDirection={defaultDirection}
 						columns={columns}
 						rows={Array(getParam('i') ? getParam('i') : 10).fill({})} // Simulate rows
 						limit={getParam('i')}
@@ -198,6 +200,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 						rowStyle={rowStyle}
 					/>
 					: <DataTable2
+						defaultDirection={defaultDirection}
 						columns={columns}
 						rows={rows}
 						limit={getParam('i')}
@@ -290,7 +293,7 @@ export function DataTableCardFooter2({page, limit, count, rows, isLoading}) {
 }
 
 
-export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle}) {
+export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle, defaultDirection}) {
 	return (
 		<Table className="datatable2 placeholder-glow">
 			<colgroup>
@@ -305,6 +308,7 @@ export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle})
 						<th key={idx} style={column?.thStyle} className="pt-0" id={`datatable-column-${idx}`}>
 							{column?.sort ?
 								<DataTableSort2
+									defaultDirection={defaultDirection}
 									title={column?.title}
 									field={column.sort}
 								/>
@@ -431,35 +435,48 @@ function DataTableBadge({ item, value, isLoading, onRemove }) {
 }
 
 // Inner sorting function
-function DataTableSort2({title, field}) {
+function DataTableSort2({ title, field, defaultDirection = 'a' }) {
 	const { onTriggerSort, getParam } = useDataTableContext();
 	const { t } = useTranslation();
 
+	const currentDirection = getParam(`s${field}`);
+
+	const getNextDirection = () => {
+		if (!currentDirection) {
+			return defaultDirection;
+		}
+		return currentDirection === 'd' ? 'a' : 'd';
+	};
+
+	const nextDirection = getNextDirection();
+
 	return (
-		getParam(`s${field}`) ?
-			(getParam(`s${field}`) == "d") ?
-				<span className="sort-span-wrapper" onClick={(e) => onTriggerSort(e, field, "a")}>
-					{title}
-					<i
-						title={`${t('General|Sort ascend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
-						className="bi bi-sort-up sort-icon-active ms-2"
-					></i>
-				</span>
-				:
-				<span className="sort-span-wrapper" onClick={(e) => onTriggerSort(e, field, "d")}>
-					{title}
-					<i
-						title={`${t('General|Sort descend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
-						className="bi bi-sort-down-alt sort-icon-active ms-2"
-					></i>
-				</span>
-			:
-				<span className="sort-span-wrapper" onClick={(e) => onTriggerSort(e, field, "a")}>
-					{title}
-					<i
-						title={t('General|Shift + left mouse click for advanced sorting')}
-						className="bi bi-arrow-down-up ms-2"
-					></i>
-				</span>
-	)
+		<span
+			className='sort-span-wrapper'
+			onClick={(e) => onTriggerSort(e, field, nextDirection)}
+		>
+      		{title}
+
+			{currentDirection === 'd' && (
+				<i
+					title={`${t('General|Sort ascend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
+					className='bi bi-sort-up sort-icon-active ms-2'
+				/>
+			)}
+
+			{currentDirection === 'a' && (
+				<i
+					title={`${t('General|Sort descend')}. ${t('General|Shift + left mouse click to remove from sorting')}`}
+					className='bi bi-sort-down-alt sort-icon-active ms-2'
+				/>
+			)}
+
+			{!currentDirection && (
+				<i
+					title={t('General|Shift + left mouse click for advanced sorting')}
+					className='bi bi-arrow-down-up ms-2'
+				/>
+			)}
+    </span>
+	);
 }

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -82,7 +82,7 @@ If not provided, the default behavior remains unchanged (sorting starts with asc
 	defaultSortDirection='d'
 />
 ```
-**Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ("a") and descending ("d") as usual.
+**Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ('a') and descending ('d') as usual.
 
 ## Columns
 

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -119,9 +119,6 @@ Use with sort:
 import { DataTableCard2, DataTableSort2 } from "asab_webui_components";
 ...
 
-const [sort, setSort] = useState([]);
-...
-
 const columns = [
 	{
 		title: "Session",

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -70,20 +70,6 @@ To remove footer from the DataTable2, `hideFooter={true}` should be set.
 />
 ```
 
-Use with custom default sorting direction. If defaultSortDirection is set, the first click on a sortable column will use this direction ('a' for ascending or 'd' for descending`).
-If not provided, the default behavior remains unchanged (sorting starts with ascending).
-
-```
-<DataTableCard2
-	app={app}
-	columns={columns}
-	loader={loader}
-	header={<Header />}
-	defaultSortDirection='d'
-/>
-```
-**Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ('a') and descending ('d') as usual.
-
 ## Columns
 
 Provides info about columns in the data table
@@ -150,6 +136,61 @@ const columns = [
 		title: "Credentials",
 		thStyle: {minWidth: "2rem"},
 		sort: "credentials_id",
+		render: ({ row }) =>
+			<Link to={`/auth/credentials/${row.credentials_id}`}>
+				{row.credentials_id}
+			</Link>
+	},
+	{
+		title: "Created at",
+		thStyle: {minWidth: "4rem"},
+		render: ({ row }) => <DateTime value={row._c}/>
+	},
+	{
+		title: "Expected expiration",
+		thStyle: {minWidth: "4rem"},
+		render: ({ row }) => <DateTime value={row.expiration}/>
+	},
+	{
+		thStyle: {width: "0px"}, // This is how you do the column for buttons
+		tdStyle: {padding: "0px", whiteSpace: "nowrap"},
+		render: ({ row, column }) => (<>
+			<button className="btn btn-primary me-1" onClick={() => onYClick(row)}><i className="bi bi-check"></i></button>
+			<button className="btn btn-danger" onClick={() => onXClick(row)}><i className="bi bi-trash"></i></button>
+		</>)
+	}
+];
+```
+
+Use with sort direction:
+
+Use with custom default sorting direction. If `sortDirection` is set, the first click on a sortable column will use this direction ('a' for ascending or 'd' for descending`).
+If not provided, the default behavior remains unchanged (sorting starts with ascending).
+
+**Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ('a') and descending ('d') as usual.
+```
+import { DataTableCard2, DataTableSort2 } from "asab_webui_components";
+...
+
+const [sort, setSort] = useState([]);
+...
+
+const columns = [
+	{
+		title: "Session",
+		thStyle: {minWidth: "2rem"},
+		sort: "_id",
+		sortDirection: 'd',
+		render: ({ row }) =>
+			<Link to={`/auth/session/${row._id}`}>
+				{row._id}
+			</Link>
+	},
+	{
+		title: "Credentials",
+		thStyle: {minWidth: "2rem"},
+		sort: "credentials_id",
+		sortDirection: 'd',
 		render: ({ row }) =>
 			<Link to={`/auth/credentials/${row.credentials_id}`}>
 				{row.credentials_id}

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -70,6 +70,20 @@ To remove footer from the DataTable2, `hideFooter={true}` should be set.
 />
 ```
 
+Use with custom default sorting direction. If defaultSortDirection is set, the first click on a sortable column will use this direction ('a' for ascending or 'd' for descending`).
+If not provided, the default behavior remains unchanged (sorting starts with ascending).
+
+```
+<DataTableCard2
+	app={app}
+	columns={columns}
+	loader={loader}
+	header={<Header />}
+	defaultSortDirection='d'
+/>
+```
+**Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ("a") and descending ("d") as usual.
+
 ## Columns
 
 Provides info about columns in the data table

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -164,17 +164,13 @@ const columns = [
 
 Use with sort direction:
 
+`sortDirection` - optional prop
+
 Use with custom default sorting direction. If `sortDirection` is set, the first click on a sortable column will use this direction ('a' for ascending or 'd' for descending`).
-If not provided, the default behavior remains unchanged (sorting starts with ascending).
+If not provided, the default behavior remains unchanged (sorting starts with ascending - 'a').
 
 **Note:** This property only affects the initial sorting direction when a column is sorted for the first time. Subsequent clicks will toggle between ascending ('a') and descending ('d') as usual.
 ```
-import { DataTableCard2, DataTableSort2 } from "asab_webui_components";
-...
-
-const [sort, setSort] = useState([]);
-...
-
 const columns = [
 	{
 		title: "Session",
@@ -196,24 +192,7 @@ const columns = [
 				{row.credentials_id}
 			</Link>
 	},
-	{
-		title: "Created at",
-		thStyle: {minWidth: "4rem"},
-		render: ({ row }) => <DateTime value={row._c}/>
-	},
-	{
-		title: "Expected expiration",
-		thStyle: {minWidth: "4rem"},
-		render: ({ row }) => <DateTime value={row.expiration}/>
-	},
-	{
-		thStyle: {width: "0px"}, // This is how you do the column for buttons
-		tdStyle: {padding: "0px", whiteSpace: "nowrap"},
-		render: ({ row, column }) => (<>
-			<button className="btn btn-primary me-1" onClick={() => onYClick(row)}><i className="bi bi-check"></i></button>
-			<button className="btn btn-danger" onClick={() => onXClick(row)}><i className="bi bi-trash"></i></button>
-		</>)
-	}
+	...
 ];
 ```
 


### PR DESCRIPTION
This MR introduces an improvement to the sorting behavior in DataTable2 by adding a new optional prop:
```sortDirection```
This enhancement was requested by users and will be applied to the Alerts table.

_I've attached a video of this prop working in Gitlab._


---

### Problem:
Currently, when a user clicks on a sortable column:
- The first click applies ascending sorting ("a").
- In many real user scenarios (especially in Alerts), users expect to see descending results first (e.g., newest items on top).
- As a result, users must click the sort icon twice to get the expected result.
This causes confusion and creates unnecessary interaction friction.

---
### What Was Added

1. New prop: sortDirection
 - Accepts "a" (ascending) or "d" (descending).
 - Defines the sorting direction applied on the first click when the column is not yet sorted.

2. Backward compatibility preserved
 - If sortDirection is not provided, behavior remains unchanged.
 - Existing tables continue to work exactly as before.

3. Planned usage
 - This prop will be used in the Alerts table, where users expect descending order (e.g., latest alerts first) immediately after a single click.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DataTable2 columns now support an optional `sortDirection` prop to customize the initial sort direction when users first click a column header for sorting.

* **Documentation**
  * Updated DataTable2 documentation with comprehensive examples and guidance for implementing the new `sortDirection` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->