### PR TITLE
Fix on ipv6 serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.7
+
+- Fix on normalization of IPV6 values (#70)
+
 ## 27.3.6
 
 - Set `escapeValues` to `true` in ErrorHandler translation util component to prevent potential XSS attacks. (#67)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.6",
+	"version": "27.3.7",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -505,9 +505,21 @@ const stringifyIPv6 = (bigintIP6Address) => {
 	}
 
 	// Join the parts with colons to form the final compressed IPv6 address.
-	const result = parts.join(':');
-	// All-zero address (e.g. "::") compresses to a single empty segment ""; canonical form is "::"
-	return result === '' ? '::' : result;
+	let result = parts.join(':');
+	// All-zero address compresses to a single empty segment ""; canonical form is "::"
+	if (result === '') {
+		return '::';
+	}
+	// Boundary compression: empty segment at start/end produces ":1" or "1:" instead of "::1" or "1::"
+	if (result.startsWith(':') && !result.startsWith('::')) {
+		result = ':' + result;
+	}
+
+	if (result.endsWith(':') && !result.endsWith('::')) {
+		result = result + ':';
+	}
+
+	return result;
 };
 
 const stringifyIPv4 = (bigintIP4Address) => {

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -505,7 +505,9 @@ const stringifyIPv6 = (bigintIP6Address) => {
 	}
 
 	// Join the parts with colons to form the final compressed IPv6 address.
-	return parts.join(':');
+	const result = parts.join(':');
+	// All-zero address (e.g. "::") compresses to a single empty segment ""; canonical form is "::"
+	return result === '' ? '::' : result;
 };
 
 const stringifyIPv4 = (bigintIP4Address) => {

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -514,7 +514,6 @@ const stringifyIPv6 = (bigintIP6Address) => {
 	if (result.startsWith(':') && !result.startsWith('::')) {
 		result = ':' + result;
 	}
-
 	if (result.endsWith(':') && !result.endsWith('::')) {
 		result = result + ':';
 	}


### PR DESCRIPTION
- this is a fix on IPV6 serialization, where when `::` address was serialized, the `normalizedValue` was returned as an empty string
- this caused issues in displaying the IPV6 address and disallowed any action over the value



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IPv6 compression/normalization so the all-zero address renders as "::" and leading/trailing zero-compression produces canonical forms.
* **Chore**
  * Bumped package version and added corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->