### PR TITLE
Fix on datatable filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.9
+
+- Fix on datatable filtering issue, when the rows were decreasing everytime a new filter has been applied (#71)
+
 ## 27.3.8
 
 - Add `sortDirection` prop for DataTable2 for Columns sorting. Update docs for DataTable2 (#66)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.8",
+	"version": "27.3.9",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DataTable2/DataTableContext.jsx
+++ b/src/components/DataTable2/DataTableContext.jsx
@@ -89,7 +89,14 @@ const DataTableContextProvider = ({ children, disableParams, initialLimit }) => 
 					updatedSearchParams.append(key, value);
 				}
 			})
-			updateLimit("decrease", updatedSearchParams);
+			/*	Only decrease limit when adding the very first filtering.
+				Check original params (including the field being replaced) so that
+				replacing an existing filter does not decrease the limit a second time
+			*/
+			const isFirstFilter = ![...searchParams.entries()].some(([key]) => key.startsWith('a'));
+			if (isFirstFilter) {
+				updateLimit("decrease", updatedSearchParams);
+			}
 			updatedSearchParams.set("p", 1);
 			updatedSearchParams.append(`a${field}`, value);
 			setSearchParams(updatedSearchParams);
@@ -102,7 +109,11 @@ const DataTableContextProvider = ({ children, disableParams, initialLimit }) => 
 						updatedState[key] = prevState[key];
 					}
 				});
-				updateStateLimit("decrease", updatedState);
+				// Same check against the original prevState (before stripping the field)
+				const isFirstFilter = !Object.keys(prevState).some(key => key.startsWith('a'));
+				if (isFirstFilter) {
+					updateStateLimit("decrease", updatedState);
+				}
 				updatedState['p'] = 1;
 				updatedState[`a${field}`] = [value];
 				return updatedState;


### PR DESCRIPTION
- fix on datatable filtering issue, when the rows were decreasing everytime a new filter has been applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Data table advanced filters now behave correctly when adding or replacing filters, preventing unintended decreases in visible rows.
* **Documentation**
  * Changelog updated with version 27.3.9 entry describing the DataTable filtering fix.
* **Chores**
  * Package version bumped to 27.3.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->