### PR TITLE
Add prop for DataTableFilter2 for controll autofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.10
+
+- Add prop `focus` for controlling autofocus in the DataTableFilter2 (#72)
+
 ## 27.3.9
 
 - Fix on datatable filtering issue, when the rows were decreasing everytime a new filter has been applied (#71)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.9",
+	"version": "27.3.10",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DataTable2/components/filters/DataTableSimpleFilter2.jsx
+++ b/src/components/DataTable2/components/filters/DataTableSimpleFilter2.jsx
@@ -7,7 +7,7 @@ import {
 
 import { useDataTableContext } from '../../DataTableContext.jsx';
 
-export function DataTableFilter2() {
+export function DataTableFilter2({ focus = true}) {
 	const { getParam, setParams } = useDataTableContext();
 	const { t } = useTranslation();
 
@@ -19,15 +19,15 @@ export function DataTableFilter2() {
 	return (
 		<div>
 			<InputGroup>
-				<InputGroupText><i className="bi bi-search"></i></InputGroupText>
+				<InputGroupText><i className='bi bi-search' /></InputGroupText>
 				<Input
-					autoFocus
-					value={getParam("f") ? getParam("f") : ""}
+					autoFocus={focus}
+					value={getParam('f') ? getParam('f') : ''}
 					onChange={(e) => {onFilterChange(e)}}
 					placeholder={t('General|Search')}
-					type="text"
-					bsSize="sm"
-					name="table-simple-filter"
+					type='text'
+					bsSize='sm'
+					name='table-simple-filter'
 				/>
 			</InputGroup>
 		</div>

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -368,6 +368,9 @@ const Header = () => {
 }
 ```
 
+**Note:** For the `DataTableFilter2`, it is possible to turn off autofocus using the optional prop `<DataTableFilter2 focus={false} />`. `focus`
+
+
 With advanced filter (multi and single value):
 
 ```


### PR DESCRIPTION
Add `focus` prop for  DataTableFilter2.

Defaul is `true`. If you need to turn off the focus, then you need to pass `focus ={false}`