### PR TITLE
Pin axios dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.3.10
+
+- Temporaly pin the `axios` version within range of `1.8.4` to `1.14.0` included (#73)
+
 ## 27.3.9
 
 - Fix on datatable filtering issue, when the rows were decreasing everytime a new filter has been applied (#71)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.22.11",
-		"axios": "1.14.0",
+		"axios": ">=1.8.4 <1.14.1",
 		"bootstrap": "^5.3.1",
 		"bootstrap-icons": "^1.10.5",
 		"date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.3.9",
+	"version": "27.3.10",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [
@@ -45,7 +45,7 @@
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.22.11",
-		"axios": "^1.8.4",
+		"axios": "1.14.0",
 		"bootstrap": "^5.3.1",
 		"bootstrap-icons": "^1.10.5",
 		"date-fns": "^4.1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 27.3.10
  * Updated axios compatibility to support newer 1.x releases up to 1.14.0 (tightened peer dependency range)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->