### PR TITLE
Make DataTable2 Rows Per Page Values Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.4.3
+
+- Add optional prop to set `DataTableCard2` and `DataTableCardFooter2` custom row limits per page (#75)
+
 ## 27.4.2
 
 - Unpin the `axios` version to `^1.15.0` (#74)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.4.2",
+	"version": "27.4.3",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -14,7 +14,8 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 import './DataTable2.scss';
 
 // Wrapper for datatable context
-export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle }) {
+export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38,
+								   disableParams = undefined, hideFooter = false, rowStyle, limitValues = [10, 20, 50, 100] }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -26,13 +27,14 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 				rowHeight={rowHeight}
 				rowStyle={rowStyle}
 				hideFooter={hideFooter}
+				limitValues={limitValues}
 			/>
 		</DataTableContextProvider>
 	);
 }
 
 
-function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
+function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter, limitValues }) {
 	// Getting application object and PubSub subscription
 	const { app, subscribe } = usePubSub();
 	const { watchParams, getParam, setParams, serializeParams } = useDataTableContext();
@@ -213,16 +215,16 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 				count={count}
 				rows={rows}
 				isLoading={isLoading}
+				limitValues={limitValues}
 			/>}
 		</div>
 	);
 }
 
-export function DataTableCardFooter2({page, limit, count, rows, isLoading}) {
+export function DataTableCardFooter2({page, limit, count, rows, isLoading, limitValues}) {
 	const { getParam, setParams } = useDataTableContext();
 	const { t } = useTranslation();
 	const [ isLimitDropDownOpen, setLimitDropDownOpen ] = useState(false);
-	const limitValues = [10, 20, 50, 100];
 
 	const nextPage = () => {
 		if ((count == undefined) && (limit === rows.length)) {

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -13,9 +13,11 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 
 import './DataTable2.scss';
 
+const DEFAULT_LIMIT_VALUES = [10, 20, 50, 100];
+
 // Wrapper for datatable context
 export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38,
-								   disableParams = undefined, hideFooter = false, rowStyle, limitValues = [10, 20, 50, 100] }) {
+								   disableParams = undefined, hideFooter = false, rowStyle, limitValues = DEFAULT_LIMIT_VALUES }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -221,7 +223,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 	);
 }
 
-export function DataTableCardFooter2({page, limit, count, rows, isLoading, limitValues}) {
+export function DataTableCardFooter2({page, limit, count, rows, isLoading, limitValues = DEFAULT_LIMIT_VALUES}) {
 	const { getParam, setParams } = useDataTableContext();
 	const { t } = useTranslation();
 	const [ isLimitDropDownOpen, setLimitDropDownOpen ] = useState(false);

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -70,6 +70,18 @@ To remove footer from the DataTable2, `hideFooter={true}` should be set.
 />
 ```
 
+To set custom row limits per page, `limitValues={number[]}` should be set.
+
+```
+<DataTableCard2
+	app={app}
+	columns={columns}
+	loader={loader}
+	header={<Header />}
+	limitValues={[5, 10, 20, 50]}
+/>
+```
+
 ## Columns
 
 Provides info about columns in the data table

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -70,7 +70,7 @@ To remove footer from the DataTable2, `hideFooter={true}` should be set.
 />
 ```
 
-To set custom row limits per page, `limitValues={number[]}` should be set.
+To set custom row limits per page, `limitValues={number[]}` should be set. Default values are currently `[10, 20, 50, 100]`.
 
 ```
 <DataTableCard2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data tables now support customizable page-size options; the "items per page" dropdown can be configured with custom values and includes sensible defaults.
* **Documentation**
  * Component docs updated with usage guidance and an example for custom per-page options.
* **Chores**
  * Release entry and package version updated for this patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->