### PR TITLE
Memoize header and rename props

### DIFF
--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -30,6 +30,14 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 		</DataTableContextProvider>
 	);
 }
+
+const DataTableCardContent = memo(function DataTableCardContent({ header }) {
+	return (
+		<CardHeader className="card-header-flex">
+			{header}
+		</CardHeader>
+	);
+})
 
 
 function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
@@ -183,9 +191,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 
 	return (
 		<div className={`card ${className || ''}`} ref={cardRef}>
-			<CardHeader className="card-header-flex">
-				{header}
-			</CardHeader>
+			<DataTableCardContent header={header} />
 			<CardBody className='datatable2-card-body'>
 				<DataTableCardPill2 isLoading={isLoading} rowHeight={rowHeight}/>
 				{isLoading

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -31,13 +31,13 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 	);
 }
 
-const DataTableCardContent = memo(function DataTableCardContent({ header }) {
+const DataTableCardHeader = memo(function DataTableCardHeader({ header }) {
 	return (
 		<CardHeader className="card-header-flex">
 			{header}
 		</CardHeader>
 	);
-})
+});
 
 
 function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
@@ -191,7 +191,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 
 	return (
 		<div className={`card ${className || ''}`} ref={cardRef}>
-			<DataTableCardContent header={header} />
+			<DataTableCardHeader header={header} />
 			<CardBody className='datatable2-card-body'>
 				<DataTableCardPill2 isLoading={isLoading} rowHeight={rowHeight}/>
 				{isLoading

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -323,22 +323,23 @@ export function DataTable2({columns, rows, limit, loading, rowHeight, rowStyle})
 			</thead>
 
 			<tbody>
-				{rows.map((row, ridx) => (
-					<tr key={ridx} style={{ ...rowStyle ? rowStyle(row) : {}, height: rowHeight }}>
-						{ loading
-						? <td colSpan={columns.length}>
-							<span className="placeholder w-100 bg-secondary"></span>
-						</td>
-						: columns.map((column, cidx) =>
-							<td key={cidx} style={column?.tdStyle}>
-								{ (column?.render != undefined)
-								? column.render({row, column, ridx})
-								: <span className="placeholder w-100 bg-secondary" title="Missing render method"></span>
-								}
+				{rows.map((row, ridx) => {
+					return (
+						<tr key={ridx} style={{ ...rowStyle ? rowStyle(row) : {}, height: rowHeight }}>
+							{ loading
+							? <td colSpan={columns.length}>
+								<span className="placeholder w-100 bg-secondary"></span>
 							</td>
-						)}
-					</tr>
-				))}
+							: columns.map((column, cidx) =>
+								<td key={cidx} style={column?.tdStyle}>
+									{ (column?.render != undefined)
+									? column.render({row, column, ridx})
+									: <span className="placeholder w-100 bg-secondary" title="Missing render method"></span>
+									}
+								</td>
+							)}
+						</tr>
+				)})}
 			</tbody>
 
 			{(limit - rows.length > 0) && <tfoot /* This is rendering of the empty rows to make height of table fixed */>

--- a/src/components/DataTable2/DataTable2.jsx
+++ b/src/components/DataTable2/DataTable2.jsx
@@ -14,7 +14,7 @@ import { DataTableContextProvider, useDataTableContext } from './DataTableContex
 import './DataTable2.scss';
 
 // Wrapper for datatable context
-export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, hideFooter = false, rowStyle }) {
+export function DataTableCard2({ columns, loader, loaderParams, header, className, initialLimit = 0, rowHeight = 38, disableParams = undefined, disableFooter = false, rowStyle }) {
 	return (
 		<DataTableContextProvider disableParams={disableParams} initialLimit={initialLimit}>
 			<DataTableCardContent
@@ -25,7 +25,7 @@ export function DataTableCard2({ columns, loader, loaderParams, header, classNam
 				className={className}
 				rowHeight={rowHeight}
 				rowStyle={rowStyle}
-				hideFooter={hideFooter}
+				disableFooter={disableFooter}
 			/>
 		</DataTableContextProvider>
 	);
@@ -40,7 +40,7 @@ const DataTableCardHeader = memo(function DataTableCardHeader({ header }) {
 });
 
 
-function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, hideFooter }) {
+function DataTableCardContent({ columns, loader, loaderParams, header, className, rowHeight, rowStyle, disableFooter }) {
 	// Getting application object and PubSub subscription
 	const { app, subscribe } = usePubSub();
 	const { watchParams, getParam, setParams, serializeParams } = useDataTableContext();
@@ -212,7 +212,7 @@ function DataTableCardContent({ columns, loader, loaderParams, header, className
 					/>
 				}
 			</CardBody>
-			{!hideFooter &&
+			{!disableFooter &&
 			<DataTableCardFooter2
 				page={getParam('p')}
 				limit={getParam('i')}

--- a/src/components/DataTable2/readme.md
+++ b/src/components/DataTable2/readme.md
@@ -34,7 +34,7 @@ const rowStyle = (row) => {
 	}
 	return null;
 };
-	
+
 ...
 
 <DataTableCard2
@@ -58,7 +58,7 @@ To disable searchParams of the DataTable2, `disableParams={true}` is used to cha
 />
 ```
 
-To remove footer from the DataTable2, `hideFooter={true}` should be set.
+To remove footer from the DataTable2, `disableFooter={true}` should be set.
 
 ```
 <DataTableCard2
@@ -66,7 +66,7 @@ To remove footer from the DataTable2, `hideFooter={true}` should be set.
 	columns={columns}
 	loader={loader}
 	header={<Header />}
-	hideFooter={true}
+	disableFooter={true}
 />
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * DataTable2 component’s `hideFooter` prop has been renamed to `disableFooter` (defaults to `false`). This is a breaking change—review and update any existing code using `hideFooter`.
  * Footer visibility now follows `disableFooter` consistently throughout the table card.
* **Documentation**
  * Updated DataTable2 usage examples and explanatory text to use `disableFooter` instead of `hideFooter`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->