### PR TITLE
Update ip titles in the classifyIPAdresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Components
 
+## 27.4.3
+
+- More understandable messages have been added for `IPv4` and `IPv6` in the `classifyIpAddresses` (#79)
+
 ## 27.4.2
 
 - Unpin the `axios` version to `^1.15.0` (#74)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_components",
-	"version": "27.4.2",
+	"version": "27.4.3",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Components Library",
 	"contributors": [

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -379,7 +379,7 @@ function classifyIPv4(ipAddress) {
 		cls: "public",
 		family: "IPv4",
 		normalizedValue: stringifyIPv4(ipAddress),
-		msg: "IPv4 public"
+		msg: "IPv4 Public Address"
 	}
 }
 
@@ -398,7 +398,7 @@ function classifyIPv6(ipAddress) {
 		cls: "public",
 		family: "IPv6",
 		normalizedValue: stringifyIPv6(ipAddress),
-		msg: "IPv6 public"
+		msg: "IPv6 Public Address"
 	}
 }
 

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -179,7 +179,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation (TEST-NET)"
+			msg: "IPv4 Address from documentation range"
 		}
 	},
 	{
@@ -189,7 +189,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 6to4 relay"
+			msg: "IPv4 Address for 6to4 relay"
 		}
 	},
 	{
@@ -208,7 +208,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation (TEST-NET)"
+			msg: "IPv4 Address from documentation range"
 		}
 	},
 	{
@@ -218,7 +218,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation (TEST-NET)"
+			msg: "IPv4 Address from documentation range"
 		}
 	},
 	{
@@ -270,7 +270,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 NAT64 translation"
+			msg: "IPv6 Address from NAT64 translation"
 		}
 	},
 	{
@@ -299,7 +299,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 Teredo tunnel"
+			msg: "IPv6 Address from Teredo tunnel"
 		}
 	},
 	{
@@ -319,7 +319,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 documentation (TEST-NET)"
+			msg: "IPv6 Address from documentation range"
 		}
 	},
 	{
@@ -329,7 +329,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 ORCHID"
+			msg: "IPv6 Address used for ORCHID"
 		}
 	},
 	{
@@ -339,7 +339,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 6to4 transition"
+			msg: "IPv6 Address from 6to4 transition range"
 		}
 	},
 	{
@@ -349,7 +349,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv6",
-			msg: "IPv6 unique-local (ULA)"
+			msg: "unique-local IPv6 Address (ULA)"
 		}
 	},
 	{

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -179,7 +179,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation"
+			msg: "IPv4 documentation (TEST-NET)"
 		}
 	},
 	{
@@ -189,7 +189,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 6to4"
+			msg: "IPv4 6to4 relay"
 		}
 	},
 	{
@@ -208,7 +208,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation"
+			msg: "IPv4 documentation (TEST-NET)"
 		}
 	},
 	{
@@ -218,7 +218,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 documentation"
+			msg: "IPv4 documentation (TEST-NET)"
 		}
 	},
 	{
@@ -270,7 +270,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 IPv4-IPv6"
+			msg: "IPv6 NAT64 translation"
 		}
 	},
 	{
@@ -299,7 +299,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 terredo"
+			msg: "IPv6 Teredo tunnel"
 		}
 	},
 	{
@@ -319,7 +319,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 documentation"
+			msg: "IPv6 documentation (TEST-NET)"
 		}
 	},
 	{
@@ -329,7 +329,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 orchid"
+			msg: "IPv6 ORCHID"
 		}
 	},
 	{
@@ -339,7 +339,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 6to4"
+			msg: "IPv6 6to4 transition"
 		}
 	},
 	{
@@ -349,7 +349,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv6",
-			msg: "IPv6 unique local"
+			msg: "IPv6 unique-local (ULA)"
 		}
 	},
 	{

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -85,7 +85,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv4",
-			msg: "IPv4 private"
+			msg: "IPv4 Private Address"
 		}
 	},
 	{
@@ -95,7 +95,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv4",
-			msg: "IPv4 private"
+			msg: "IPv4 Private Address"
 		}
 	},
 	{
@@ -104,7 +104,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv4",
-			msg: "IPv4 private"
+			msg: "IPv4 Private Address"
 		}
 	},
 	{
@@ -113,7 +113,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 reserved"
+			msg: "IPv4 Reserved Address"
 		}
 	},
 	{
@@ -122,7 +122,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 reserved"
+			msg: "IPv4 Reserved Address"
 		}
 	},
 	{
@@ -132,7 +132,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 link-local"
+			msg: "IPv4 Link-Local Address"
 		}
 	},
 	{
@@ -151,7 +151,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 loopback"
+			msg: "IPv4 Loopback Address"
 		}
 	},
 	{
@@ -160,7 +160,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 reserved"
+			msg: "IPv4 Reserved Address"
 		}
 	},
 	{
@@ -169,7 +169,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 ds-lite"
+			msg: "IPv4 DS-Lite Address"
 		}
 	},
 	{
@@ -198,7 +198,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 benchmarking"
+			msg: "IPv4 Benchmarking Address"
 		}
 	},
 	{
@@ -228,7 +228,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 reserved"
+			msg: "IPv4 Reserved Address"
 		}
 	},
 	{
@@ -237,7 +237,7 @@ const ipv4Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv4",
-			msg: "IPv4 limited-broadcast"
+			msg: "IPv4 Limited Broadcast Address"
 		}
 	}	
 ]
@@ -250,7 +250,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 loopback"
+			msg: "IPv6 Loopback Address"
 		}
 	},
 	{
@@ -260,7 +260,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 unspecified"
+			msg: "IPv6 Unspecified Address"
 		}
 	},
 	{
@@ -279,7 +279,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 IPv4-mapped"
+			msg: "IPv6 IPv4-Mapped Address"
 		}
 	},
 	{
@@ -289,7 +289,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 discard"
+			msg: "IPv6 Discard Address"
 		}
 	},
 	{
@@ -309,7 +309,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 benchmarking"
+			msg: "IPv6 Benchmarking Address"
 		}
 	},
 	{
@@ -358,7 +358,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "special",
 			family: "IPv6",
-			msg: "IPv6 link-local"
+			msg: "IPv6 Link-Local Address"
 		}
 	}
 ]

--- a/src/utils/classifyIPAddress.js
+++ b/src/utils/classifyIPAddress.js
@@ -349,7 +349,7 @@ const ipv6Ranges = [
 		attrs: {
 			cls: "private",
 			family: "IPv6",
-			msg: "unique-local IPv6 Address (ULA)"
+			msg: "Unique-local IPv6 Address (ULA)"
 		}
 	},
 	{


### PR DESCRIPTION
**Problem: When hovering over IP address: I don't know what is "IPv4 documentation" **


More understandable titles have been added, especially the `IPv4 documentation` and `IPv6 documentation` titles have been replaced.

`IPv4 documentation` ===> `IPv4 Address from documentation range`
`IPv6 documentation` ===> `IPv6 Address from documentation range`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the clarity and wording of diagnostic/classification messages for special IPv4 and IPv6 address ranges, including more explicit “public,” “private/reserved,” and other category labels.
* **Chores**
  * Added a new `27.5.1` entry to the changelog.
  * Bumped the package version to `27.5.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->